### PR TITLE
DDP Support Refactor and Cleanup

### DIFF
--- a/core.go
+++ b/core.go
@@ -137,6 +137,9 @@ type (
 		qos       QOSLevel               // not exported to JSON
 	}
 
+	// A callback function that handles a device command.
+	CommandHandler func(*DeviceContext, *DeviceCommand)
+
 	// KeyValue represents a key-value pair stored in the Device Data Proxy.
 	KeyValue struct {
 		Key              string      `json:"key"`
@@ -144,17 +147,17 @@ type (
 		ModificationTime time.Time   `json:"modificationTime"`
 	}
 
-	// A callback function that handles a device command.
-	CommandHandler func(*DeviceContext, *DeviceCommand)
+	// A callback function that is invoked when the Device Data Proxy is ready
+	// to be accessed.
+	KeyValuesReadyCallback func(*DeviceContext)
 
-	// A callback function that handles a full reload of all key-value pairs.
-	KvReloadHandler func(*DeviceContext, []*KeyValue)
+	// A callback function that is invoked when a key-value pair has been added
+	// or updated.
+	KeyValueStoredCallback func(*DeviceContext, *KeyValue)
 
-	// A callback function that handles an update to a key-value pair.
-	KvSetHandler func(*DeviceContext, *KeyValue)
-
-	// A callback function that handles a deletion of a key-value pair.
-	KvDeleteHandler func(*DeviceContext, string)
+	// A callback function that is invoked when a key-value pair has been deleted.
+	// The key of the deleted key-value is passed in the argument.
+	KeyValueDeletedCallback func(*DeviceContext, string)
 )
 
 // ProvisionDevice is used for on-demand device provisioning. It takes a
@@ -231,6 +234,10 @@ func (cmd *DeviceCommand) String() string {
 	} else {
 		return fmt.Sprintf("{Action:\"%s\", Parameters:%s}", cmd.Action, string(cmd.payload))
 	}
+}
+
+func (kv *KeyValue) String() string {
+	return fmt.Sprintf("{Key:\"%s\", Value:%v, LastModified:%s}", kv.Key, kv.Value, kv.ModificationTime.Format(time.RFC3339))
 }
 
 // A special JSON decoder that makes sure numbers in command parameters

--- a/core.go
+++ b/core.go
@@ -58,9 +58,9 @@ var (
 	deviceKeyValueRetryInterval      = time.Second * 5
 
 	// TBD: how much buffering should we allow?
-	eventQueueLength    = 128
-	keyValueQueueLength = 128
-	commandQueueLength  = 128
+	eventQueueLength        = 128
+	commandQueueLength      = 128
+	keyValueSyncQueueLength = 128
 )
 
 // SetRESTHostPort overrides the default REST API server host and port, and specifies
@@ -137,27 +137,24 @@ type (
 		qos       QOSLevel               // not exported to JSON
 	}
 
-	ActionKeyValue struct {
-		Action  string                 `json:"action"`
-		Key     string                 `json:"key"`
-		Value   map[string]interface{} `json:"value"`
-		Rev     int                    `json:"rev"`
-		Items   []interface{}          `json:"items"`
-		MTime   time.Time              `json:"mtime"`
-		Payload []byte
-	}
-
+	// KeyValue represents a key-value pair stored in the Device Data Proxy.
 	KeyValue struct {
-		Key   string                 `json:"key"`
-		Value map[string]interface{} `json:"value"`
+		Key              string      `json:"key"`
+		Value            interface{} `json:"value"`
+		ModificationTime time.Time   `json:"modificationTime"`
 	}
 
 	// A callback function that handles a device command.
 	CommandHandler func(*DeviceContext, *DeviceCommand)
 
-	KvReloadHandler func(*DeviceContext, []*KeyValue) bool
-	KvSetHandler    func(*DeviceContext, *KeyValue) bool
-	KvDeleteHandler func(*DeviceContext, string) bool
+	// A callback function that handles a full reload of all key-value pairs.
+	KvReloadHandler func(*DeviceContext, []*KeyValue)
+
+	// A callback function that handles an update to a key-value pair.
+	KvSetHandler func(*DeviceContext, *KeyValue)
+
+	// A callback function that handles a deletion of a key-value pair.
+	KvDeleteHandler func(*DeviceContext, string)
 )
 
 // ProvisionDevice is used for on-demand device provisioning. It takes a

--- a/core.go
+++ b/core.go
@@ -52,17 +52,20 @@ var (
 	infoLogger  = log.New(os.Stdout, "[MODE - INFO] ", log.LstdFlags)
 	errorLogger = log.New(os.Stderr, "[MODE - ERROR] ", log.LstdFlags)
 
+	// For publishing device events to cloud.
 	maxDeviceEventAttempts   uint = 3
 	deviceEventRetryInterval      = time.Second * 5
 
+	// For publishing key-value events to cloud.
 	maxKeyValueUpdateAttempts   uint = 3
 	keyValueUpdateRetryInterval      = time.Second * 5
 
 	// TBD: how much buffering should we allow?
-	eventQueueLength        = 128
-	commandQueueLength      = 128
-	keyValueSyncQueueLength = 128
-	keyValuePushQueueLength = 128
+	eventQueueLength            = 128
+	commandQueueLength          = 128
+	keyValueSyncQueueLength     = 128
+	keyValuePushQueueLength     = 128
+	keyValueCallbackQueueLength = 128
 )
 
 // SetRESTHostPort overrides the default REST API server host and port, and specifies

--- a/core.go
+++ b/core.go
@@ -52,15 +52,17 @@ var (
 	infoLogger  = log.New(os.Stdout, "[MODE - INFO] ", log.LstdFlags)
 	errorLogger = log.New(os.Stderr, "[MODE - ERROR] ", log.LstdFlags)
 
-	maxDeviceEventAttempts      uint = 3
-	maxDeviceKeyValueAttempts   uint = 3
-	deviceEventRetryInterval         = time.Second * 5
-	deviceKeyValueRetryInterval      = time.Second * 5
+	maxDeviceEventAttempts   uint = 3
+	deviceEventRetryInterval      = time.Second * 5
+
+	maxKeyValueUpdateAttempts   uint = 3
+	keyValueUpdateRetryInterval      = time.Second * 5
 
 	// TBD: how much buffering should we allow?
 	eventQueueLength        = 128
 	commandQueueLength      = 128
 	keyValueSyncQueueLength = 128
+	keyValuePushQueueLength = 128
 )
 
 // SetRESTHostPort overrides the default REST API server host and port, and specifies

--- a/examples/ddp/main.go
+++ b/examples/ddp/main.go
@@ -1,3 +1,7 @@
+/*
+This is an example of how a device can communicate with the MODE
+cloud via Device Data Proxy.
+*/
 package main
 
 import (
@@ -9,22 +13,42 @@ import (
 	mode "github.com/moderepo/device-sdk-go"
 )
 
-func initDevice() {
-	dc := &mode.DeviceContext{
-		DeviceID:  0,
-		AuthToken: "",
-	}
-	if err := mode.StartSession(dc, true); err != nil {
-		panic(err)
-	}
-}
-
 func main() {
-	initDevice()
+	dc := &mode.DeviceContext{
+		DeviceID:  0,             // change this to real device ID
+		AuthToken: "XXXXXXXXXXX", // change this to real API key assigned to device
+	}
+
+	mode.SetKeyValuesReadyCallback(func(_ *mode.DeviceContext) {
+		if kvs, err := mode.GetAllKeyValues(); err == nil {
+			fmt.Printf("Key-value pairs:\n")
+			for i, kv := range kvs {
+				fmt.Printf("  %d: %v\n", i, kv)
+			}
+		}
+	})
+
+	mode.SetKeyValueStoredCallback(func(_ *mode.DeviceContext, kv *mode.KeyValue) {
+		// If the key 'msg' is updated, echo it back to the key 'echo'.
+		if kv.Key == "msg" {
+			fmt.Printf("Echoing msg %v\n", kv.Value)
+
+			if err := mode.SetKeyValue("echo", kv.Value); err != nil {
+				fmt.Printf("Failed to set key-value: %s\n", err.Error())
+			}
+		}
+	})
+
+	// Start connection session using MQTT.
+	if err := mode.StartSession(dc, true); err != nil {
+		fmt.Printf("Failed to start session: %s\n", err.Error())
+		os.Exit(1)
+	}
 
 	c := make(chan os.Signal)
 	signal.Notify(c, syscall.SIGTERM, syscall.SIGINT)
 
 	sig := <-c
-	fmt.Printf("Signal %d\n", sig)
+	fmt.Printf("Received signal [%v]; shutting down...\n", sig)
+	mode.StopSession()
 }

--- a/examples/ddp/main.go
+++ b/examples/ddp/main.go
@@ -29,19 +29,19 @@ func main() {
 	})
 
 	mode.SetKeyValueStoredCallback(func(_ *mode.DeviceContext, kv *mode.KeyValue) {
-		// If the key 'msg' is updated, echo it back to the key 'echo'.
+		// If the key 'msg' is updated, emit a device event.
 		if kv.Key == "msg" {
-			fmt.Printf("Echoing msg %v\n", kv.Value)
+			eventData := map[string]interface{}{"msg": kv.Value}
 
-			if err := mode.SetKeyValue("echo", kv.Value); err != nil {
-				fmt.Printf("Failed to set key-value: %s\n", err.Error())
+			if err := mode.SendEvent("msgUpdated", eventData, mode.QOSAtLeastOnce); err != nil {
+				fmt.Printf("Failed to send event: %v\n", err)
 			}
 		}
 	})
 
 	// Start connection session using MQTT.
 	if err := mode.StartSession(dc, true); err != nil {
-		fmt.Printf("Failed to start session: %s\n", err.Error())
+		fmt.Printf("Failed to start session: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/kv_cache.go
+++ b/kv_cache.go
@@ -1,0 +1,203 @@
+package mode
+
+import (
+	"errors"
+	"time"
+)
+
+type (
+	keyValueSync struct {
+		Action   string      `json:"action"`
+		Revision int         `json:"rev"`
+		Key      string      `json:"key"`
+		Value    interface{} `json:"value"`
+		NumItems int         `json:"numItems"`
+		Items    []*KeyValue `json:"items"`
+	}
+
+	keyValueCacheItem struct {
+		revision         int
+		value            interface{}
+		modificationTime time.Time
+		deleted          bool
+	}
+
+	keyValueCache struct {
+		initialized bool
+		items       map[string]*keyValueCacheItem
+		syncQueue   chan *keyValueSync
+		access      chan func()
+	}
+)
+
+const (
+	kvSyncActionReload = "reload"
+	kvSyncActionSet    = "set"
+	kvSyncActionDelete = "delete"
+)
+
+var (
+	ErrCacheNotReady  = errors.New("cache not ready")
+	ErrKeyNotFound    = errors.New("key not found")
+	ErrObsoleteUpdate = errors.New("obsolete update")
+)
+
+func newKeyValueCache() *keyValueCache {
+	return &keyValueCache{
+		syncQueue: make(chan *keyValueSync, keyValueSyncQueueLength),
+		access:    make(chan func()),
+	}
+}
+
+func (cache *keyValueCache) run() {
+	logInfo("[keyValueCache] starting processing loop")
+	defer logInfo("[keyValueCache] exiting processing loop")
+
+	for {
+		select {
+		case kvSync := <-cache.syncQueue:
+			if kvSync == nil {
+				return
+			}
+
+			cache.handleSync(kvSync)
+
+		case f := <-cache.access:
+			f()
+		}
+	}
+}
+
+func (cache *keyValueCache) terminate() {
+	if cache.syncQueue != nil {
+		close(cache.syncQueue)
+		cache.syncQueue = nil
+	}
+}
+
+func (cache *keyValueCache) syncReload(kvSync *keyValueSync) error {
+	cacheItems := make(map[string]*keyValueCacheItem)
+
+	for _, item := range kvSync.Items {
+		cacheItems[item.Key] = &keyValueCacheItem{
+			revision:         kvSync.Revision,
+			value:            item.Value,
+			modificationTime: time.Now(),
+		}
+	}
+
+	logInfo("[keyValueCache] downloaded %d items", len(cacheItems))
+	cache.items = cacheItems
+	cache.initialized = true
+
+	return nil
+}
+
+func (cache *keyValueCache) syncSet(kvSync *keyValueSync) error {
+	if !cache.initialized {
+		return ErrCacheNotReady
+	}
+
+	if cacheItem, ok := cache.items[kvSync.Key]; ok {
+		if cacheItem.revision >= kvSync.Revision {
+			logInfo("[keyValueCache] ignored obsolete update (rev %d) to key '%s' (rev %d)", kvSync.Revision, kvSync.Key, cacheItem.revision)
+			return ErrObsoleteUpdate
+		}
+
+		cacheItem.revision = kvSync.Revision
+		cacheItem.value = kvSync.Value
+		cacheItem.modificationTime = time.Now()
+		cacheItem.deleted = false // just in case item was previously deleted
+		logInfo("[keyValueCache] updated value of key '%s' (new rev %d)", kvSync.Key, kvSync.Revision)
+	} else {
+		cache.items[kvSync.Key] = &keyValueCacheItem{
+			revision:         kvSync.Revision,
+			value:            kvSync.Value,
+			modificationTime: time.Now(),
+		}
+		logInfo("[keyValueCache] saved new key '%s' (new rev %d)", kvSync.Key, kvSync.Revision)
+	}
+
+	return nil
+}
+
+func (cache *keyValueCache) syncDelete(kvSync *keyValueSync) error {
+	if !cache.initialized {
+		return ErrCacheNotReady
+	}
+
+	if cacheItem, ok := cache.items[kvSync.Key]; ok {
+		if cacheItem.revision >= kvSync.Revision {
+			logInfo("[keyValueCache] ignored obsolete update (rev %d) to key '%s' (rev %d)", kvSync.Revision, kvSync.Key, cacheItem.revision)
+			return ErrObsoleteUpdate
+		}
+
+		// Mark item as deleted.
+		cacheItem.revision = kvSync.Revision
+		cacheItem.modificationTime = time.Now()
+		cacheItem.deleted = true
+		logInfo("[keyValueCache] deleted key '%s' (new rev %d)", kvSync.Key, kvSync.Revision)
+	} else {
+		// This can happen if SET and DELETE transactions are out of order.
+		// Record the delete anyway.
+		cache.items[kvSync.Key] = &keyValueCacheItem{
+			revision:         kvSync.Revision,
+			modificationTime: time.Now(),
+			deleted:          true,
+		}
+	}
+
+	return nil
+}
+
+func (cache *keyValueCache) handleSync(kvSync *keyValueSync) {
+	switch kvSync.Action {
+	case kvSyncActionReload:
+		if err := cache.syncReload(kvSync); err == nil {
+			// callback
+		}
+
+	case kvSyncActionSet:
+		if err := cache.syncSet(kvSync); err == nil {
+			// callback
+		}
+
+	case kvSyncActionDelete:
+		if err := cache.syncDelete(kvSync); err == nil {
+			// callback
+		}
+
+	default:
+		logError("[keyValueCache] received sync message with unknown action '%s'", kvSync.Action)
+	}
+}
+
+func (cache *keyValueCache) getKeyValue(key string) (*KeyValue, error) {
+	resErr := make(chan error)
+	resKV := make(chan *KeyValue)
+
+	cache.access <- func() {
+		if !cache.initialized {
+			resErr <- ErrCacheNotReady
+			return
+		}
+
+		if cacheItem, ok := cache.items[key]; ok && !cacheItem.deleted {
+			resKV <- &KeyValue{
+				Key:              key,
+				Value:            cacheItem.value,
+				ModificationTime: cacheItem.modificationTime,
+			}
+			return
+		}
+
+		resErr <- ErrKeyNotFound
+	}
+
+	select {
+	case err := <-resErr:
+		return nil, err
+	case kv := <-resKV:
+		return kv, nil
+	}
+}

--- a/mqtt.go
+++ b/mqtt.go
@@ -49,7 +49,7 @@ type (
 )
 
 func (mc *mqttConn) close() {
-	close(mc.stopPublisher) // tell uptream processor to quit
+	close(mc.stopPublisher) // tell publisher to quit
 	close(mc.doPing)        // tell pinger to quit
 
 	mc.wgWrite.Wait() // wait for event processor and pinger to finish

--- a/session.go
+++ b/session.go
@@ -1,7 +1,6 @@
 package mode
 
 import (
-	//	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -160,8 +159,9 @@ func SetSessionStateCallback(f SessionStateCallback) {
 // SetKeyValuesReadyCallback designates a function to be called when the Device
 // Data Proxy is ready to be accessed.
 //
-// IMPORTANT: This callback function runs in a separate goroutine. Please take
-// care to handle any concurrency issues.
+// IMPORTANT: key-value callbacks are queued and executed serially by a goroutine.
+// In your callback function, you should decide whether to spawn goroutines to
+// do certain work.
 func SetKeyValuesReadyCallback(f KeyValuesReadyCallback) {
 	keyValuesReadyCallback = f
 }
@@ -169,8 +169,9 @@ func SetKeyValuesReadyCallback(f KeyValuesReadyCallback) {
 // SetKeyValueStoredCallback designates a function to be called whenever a
 // key-value pair has been added or updated by someone else.
 //
-// IMPORTANT: This callback function runs in a separate goroutine. Please take
-// care to handle any concurrency issues.
+// IMPORTANT: key-value callbacks are queued and executed serially by a goroutine.
+// In your callback function, you should decide whether to spawn goroutines to
+// do certain work.
 func SetKeyValueStoredCallback(f KeyValueStoredCallback) {
 	keyValueStoredCallback = f
 }
@@ -178,8 +179,9 @@ func SetKeyValueStoredCallback(f KeyValueStoredCallback) {
 // SetKeyValueDeletedCallback designates a function to be called whenever a
 // key-value pair has been deleted by someone else.
 //
-// IMPORTANT: This callback function runs in a separate goroutine. Please take
-// care to handle any concurrency issues.
+// IMPORTANT: key-value callbacks are queued and executed serially by a goroutine.
+// In your callback function, you should decide whether to spawn goroutines to
+// do certain work.
 func SetKeyValueDeletedCallback(f KeyValueDeletedCallback) {
 	keyValueDeletedCallback = f
 }


### PR DESCRIPTION
- Refactored the Key-Value cache mechanism into `kvCache`, which coordinates the "sync" from cloud, and the update to the cloud.
- Allow key-value read-only access even when the session is in recovery state.
- Some changes to the callback definitions.
- Added godoc for exported functions/variables.
- Finished the example program.
