### PR TITLE
Fixed external dependency of MQTT code.

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,7 @@
 package: github.com/moderepo/device-sdk-go
-import:
-- package: github.com/gomqtt/packet
-  version: ~0.10.0
+import: []
+testImport:
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert

--- a/mqtt.go
+++ b/mqtt.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gomqtt/packet"
+	"github.com/moderepo/device-sdk-go/mqtt_packet"
 )
 
 const (

--- a/mqtt_packet/AUTHORS
+++ b/mqtt_packet/AUTHORS
@@ -1,0 +1,17 @@
+# This is the official list of gomqtt/packet authors for copyright purposes.
+
+# If you are submitting a patch, please add your name or the name of the
+# organization which holds the copyright to this list in alphabetical order.
+
+# Names should be added to this file as
+#	Name <email address>
+# The email address is not required for organizations.
+# Please keep the list sorted.
+
+
+# Individual Persons
+
+Jian Zhen <zhenjl@gmail.com>
+Joël Gähwiler <joel.gaehwiler@gmail.com>
+
+# Organizations

--- a/mqtt_packet/CONTRIBUTING.md
+++ b/mqtt_packet/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing Guidelines
+
+## Reporting Issues
+
+Before creating a new Issue, please check first if a similar Issue [already exists](https://github.com/gomqtt/packet/issues?state=open) or was [recently closed](https://github.com/gomqtt/packet/issues?direction=desc&page=1&sort=updated&state=closed).
+
+Please provide the following minimum information:
+* Your package version (or git SHA)
+* Your Go version (run `go version` in your console)
+* A detailed issue description
+* Error Log if present
+* If possible, a short example
+
+
+## Contributing Code
+
+By contributing to this project, you share your code under the Apache License, Version 2.0, as specified in the LICENSE file.
+Don't forget to add yourself to the AUTHORS file.
+
+### Pull Requests Checklist
+
+Please check the following points before submitting your pull request:
+- [x] Code compiles correctly
+- [x] Created tests, if possible
+- [x] All tests pass
+- [x] Extended the README / documentation, if necessary
+- [x] Added yourself to the AUTHORS file
+
+### Code Review
+
+Everyone is invited to review and comment on pull requests.
+If it looks fine to you, comment with "LGTM" (Looks good to me).
+
+If changes are required, notice the reviewers with "PTAL" (Please take another look) after committing the fixes.
+
+Before merging the Pull Request, at least one [team member](https://github.com/orgs/gomqtt/people) must have commented with "LGTM".

--- a/mqtt_packet/LICENSE
+++ b/mqtt_packet/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mqtt_packet/README.md
+++ b/mqtt_packet/README.md
@@ -1,0 +1,76 @@
+# gomqtt/packet
+
+[![Build Status](https://travis-ci.org/gomqtt/packet.svg?branch=master)](https://travis-ci.org/gomqtt/packet)
+[![Coverage Status](https://coveralls.io/repos/github/gomqtt/packet/badge.svg?branch=master)](https://coveralls.io/github/gomqtt/packet?branch=master)
+[![GoDoc](https://godoc.org/github.com/gomqtt/packet?status.svg)](http://godoc.org/github.com/gomqtt/packet)
+[![Release](https://img.shields.io/github/release/gomqtt/packet.svg)](https://github.com/gomqtt/packet/releases)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gomqtt/packet)](https://goreportcard.com/report/github.com/gomqtt/packet)
+
+**Package packet implements functionality for encoding and decoding [MQTT 3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/) packets.**
+
+## Installation
+
+Get it using go's standard toolset:
+
+```bash
+$ go get github.com/gomqtt/packet
+```
+
+## Usage
+
+```go
+/* Packet Encoding */
+
+// Create new packet.
+pkt1 := NewConnectPacket()
+pkt1.Username = "gomqtt"
+pkt1.Password = "amazing!"
+
+// Allocate buffer.
+buf := make([]byte, pkt1.Len())
+
+// Encode the packet.
+if _, err := pkt1.Encode(buf); err != nil {
+    panic(err) // error while encoding
+}
+
+/* Packet Decoding */
+
+// Detect packet.
+l, mt := DetectPacket(buf)
+
+// Check length
+if l == 0 {
+    return // buffer not complete yet
+}
+
+// Create packet.
+pkt2, err := mt.New();
+if err != nil {
+    panic(err) // packet type is invalid
+}
+
+// Decode packet.
+_, err = pkt2.Decode(buf)
+if err != nil {
+    panic(err) // there was an error while decoding
+}
+
+switch pkt2.Type() {
+case CONNECT:
+    c := pkt2.(*ConnectPacket)
+    fmt.Println(c.Username)
+    fmt.Println(c.Password)
+}
+
+// Output:
+// gomqtt
+// amazing!
+```
+
+More details can be found in the [documentation](http://godoc.org/github.com/gomqtt/packet).
+
+## Credits
+
+This package has been originally extracted and contributed by @zhenjl from the
+[surgemq](https://github.com/surgemq/surgemq) project.

--- a/mqtt_packet/connack.go
+++ b/mqtt_packet/connack.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import "fmt"
+
+// The ConnackCode represents the return code in a ConnackPacket.
+type ConnackCode uint8
+
+// All available ConnackCodes.
+const (
+	ConnectionAccepted ConnackCode = iota
+	ErrInvalidProtocolVersion
+	ErrIdentifierRejected
+	ErrServerUnavailable
+	ErrBadUsernameOrPassword
+	ErrNotAuthorized
+)
+
+// Valid checks if the ConnackCode is valid.
+func (cc ConnackCode) Valid() bool {
+	return cc <= 5
+}
+
+// Error returns the corresponding error string for the ConnackCode.
+func (cc ConnackCode) Error() string {
+	switch cc {
+	case ConnectionAccepted:
+		return "Connection accepted"
+	case ErrInvalidProtocolVersion:
+		return "Connection refused, unacceptable protocol version"
+	case ErrIdentifierRejected:
+		return "Connection refused, identifier rejected"
+	case ErrServerUnavailable:
+		return "Connection refused, Server unavailable"
+	case ErrBadUsernameOrPassword:
+		return "Connection refused, bad user name or password"
+	case ErrNotAuthorized:
+		return "Connection refused, not authorized"
+	}
+
+	return "Unknown error"
+}
+
+// A ConnackPacket is sent by the server in response to a ConnectPacket
+// received from a client.
+type ConnackPacket struct {
+	// The SessionPresent flag enables a client to establish whether the
+	// client and server have a consistent view about whether there is already
+	// stored session state.
+	SessionPresent bool
+
+	// If a well formed ConnectPacket is received by the server, but the server
+	// is unable to process it for some reason, then the server should attempt
+	// to send a ConnackPacket containing a non-zero ReturnCode.
+	ReturnCode ConnackCode
+}
+
+// NewConnackPacket creates a new ConnackPacket.
+func NewConnackPacket() *ConnackPacket {
+	return &ConnackPacket{}
+}
+
+// Type returns the packets type.
+func (cp *ConnackPacket) Type() Type {
+	return CONNACK
+}
+
+// String returns a string representation of the packet.
+func (cp *ConnackPacket) String() string {
+	return fmt.Sprintf("<ConnackPacket SessionPresent=%t ReturnCode=%d>",
+		cp.SessionPresent, cp.ReturnCode)
+}
+
+// Len returns the byte length of the encoded packet.
+func (cp *ConnackPacket) Len() int {
+	return headerLen(2) + 2
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (cp *ConnackPacket) Decode(src []byte) (int, error) {
+	total := 0
+
+	// decode header
+	hl, _, rl, err := headerDecode(src, CONNACK)
+	total += hl
+	if err != nil {
+		return total, err
+	}
+
+	// check remaining length
+	if rl != 2 {
+		return total, fmt.Errorf("[%s] expected remaining length to be 2", cp.Type())
+	}
+
+	// read connack flags
+	connackFlags := src[total]
+	cp.SessionPresent = connackFlags&0x1 == 1
+	total++
+
+	// check flags
+	if connackFlags&254 != 0 {
+		return 0, fmt.Errorf("[%s] bits 7-1 in acknowledge flags are not 0", cp.Type())
+	}
+
+	// read return code
+	cp.ReturnCode = ConnackCode(src[total])
+	total++
+
+	// check return code
+	if !cp.ReturnCode.Valid() {
+		return 0, fmt.Errorf("[%s] invalid return code (%d)", cp.Type(), cp.ReturnCode)
+	}
+
+	return total, nil
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (cp *ConnackPacket) Encode(dst []byte) (int, error) {
+	total := 0
+
+	// encode header
+	n, err := headerEncode(dst[total:], 0, 2, cp.Len(), CONNACK)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// set session present flag
+	if cp.SessionPresent {
+		dst[total] = 1 // 00000001
+	} else {
+		dst[total] = 0 // 00000000
+	}
+	total++
+
+	// check return code
+	if !cp.ReturnCode.Valid() {
+		return total, fmt.Errorf("[%s] invalid return code (%d)", cp.Type(), cp.ReturnCode)
+	}
+
+	// set return code
+	dst[total] = byte(cp.ReturnCode)
+	total++
+
+	return total, nil
+}

--- a/mqtt_packet/connack_test.go
+++ b/mqtt_packet/connack_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnackReturnCodes(t *testing.T) {
+	assert.Equal(t, ConnectionAccepted.Error(), ConnackCode(0).Error())
+	assert.Equal(t, ErrInvalidProtocolVersion.Error(), ConnackCode(1).Error())
+	assert.Equal(t, ErrIdentifierRejected.Error(), ConnackCode(2).Error())
+	assert.Equal(t, ErrServerUnavailable.Error(), ConnackCode(3).Error())
+	assert.Equal(t, ErrBadUsernameOrPassword.Error(), ConnackCode(4).Error())
+	assert.Equal(t, ErrNotAuthorized.Error(), ConnackCode(5).Error())
+	assert.Equal(t, "Unknown error", ConnackCode(6).Error())
+}
+
+func TestConnackInterface(t *testing.T) {
+	pkt := NewConnackPacket()
+
+	assert.Equal(t, pkt.Type(), CONNACK)
+	assert.Equal(t, "<ConnackPacket SessionPresent=false ReturnCode=0>", pkt.String())
+}
+
+func TestConnackPacketDecode(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		0, // session not present
+		0, // connection accepted
+	}
+
+	pkt := NewConnackPacket()
+
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.False(t, pkt.SessionPresent)
+	assert.Equal(t, ConnectionAccepted, pkt.ReturnCode)
+}
+
+func TestConnackPacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		3, // <- wrong size
+		0, // session not present
+		0, // connection accepted
+	}
+
+	pkt := NewConnackPacket()
+
+	_, err := pkt.Decode(pktBytes)
+	assert.Error(t, err)
+}
+
+func TestConnackPacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		0, // session not present
+		// <- wrong packet size
+	}
+
+	pkt := NewConnackPacket()
+
+	_, err := pkt.Decode(pktBytes)
+	assert.Error(t, err)
+}
+
+func TestConnackPacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		64, // <- wrong value
+		0,  // connection accepted
+	}
+
+	pkt := NewConnackPacket()
+
+	_, err := pkt.Decode(pktBytes)
+	assert.Error(t, err)
+}
+
+func TestConnackPacketDecodeError4(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		0,
+		6, // <- wrong code
+	}
+
+	pkt := NewConnackPacket()
+
+	_, err := pkt.Decode(pktBytes)
+	assert.Error(t, err)
+}
+
+func TestConnackPacketDecodeError5(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		1, // <- wrong remaining length
+		0,
+		6,
+	}
+
+	pkt := NewConnackPacket()
+
+	_, err := pkt.Decode(pktBytes)
+	assert.Error(t, err)
+}
+
+func TestConnackPacketEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		1, // session present
+		0, // connection accepted
+	}
+
+	pkt := NewConnackPacket()
+	pkt.ReturnCode = ConnectionAccepted
+	pkt.SessionPresent = true
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestConnackPacketEncodeError1(t *testing.T) {
+	pkt := NewConnackPacket()
+
+	dst := make([]byte, 3) // <- wrong buffer size
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestConnackPacketEncodeError2(t *testing.T) {
+	pkt := NewConnackPacket()
+	pkt.ReturnCode = 11 // <- wrong return code
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 3, n)
+}
+
+func TestConnackEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		0, // session not present
+		0, // connection accepted
+	}
+
+	pkt := NewConnackPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+
+	dst := make([]byte, pkt.Len())
+	n2, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := pkt.Decode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n3)
+}
+
+func BenchmarkConnackEncode(b *testing.B) {
+	pkt := NewConnackPacket()
+	pkt.ReturnCode = ConnectionAccepted
+	pkt.SessionPresent = true
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkConnackDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(CONNACK << 4),
+		2,
+		0, // session not present
+		0, // connection accepted
+	}
+
+	pkt := NewConnackPacket()
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/mqtt_packet/connect.go
+++ b/mqtt_packet/connect.go
@@ -1,0 +1,417 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// The supported MQTT versions.
+const (
+	Version311 byte = 4
+	Version31  byte = 3
+)
+
+var version311Name = []byte("MQTT")
+var version31Name = []byte("MQIsdp")
+
+// A ConnectPacket is sent by a client to the server after a network
+// connection has been established.
+type ConnectPacket struct {
+	// The clients client id.
+	ClientID string
+
+	// The keep alive value.
+	KeepAlive uint16
+
+	// The authentication username.
+	Username string
+
+	// The authentication password.
+	Password string
+
+	// The clean session flag.
+	CleanSession bool
+
+	// The will message.
+	Will *Message
+
+	// The MQTT version 3 or 4 (defaults to 4 when 0).
+	Version byte
+}
+
+// NewConnectPacket creates a new ConnectPacket.
+func NewConnectPacket() *ConnectPacket {
+	return &ConnectPacket{
+		CleanSession: true,
+		Version:      4,
+	}
+}
+
+// Type returns the packets type.
+func (cp *ConnectPacket) Type() Type {
+	return CONNECT
+}
+
+// String returns a string representation of the packet.
+func (cp *ConnectPacket) String() string {
+	will := "nil"
+
+	if cp.Will != nil {
+		will = cp.Will.String()
+	}
+
+	return fmt.Sprintf("<ConnectPacket ClientID=%q KeepAlive=%d Username=%q "+
+		"Password=%q CleanSession=%t Will=%s Version=%d>",
+		cp.ClientID,
+		cp.KeepAlive,
+		cp.Username,
+		cp.Password,
+		cp.CleanSession,
+		will,
+		cp.Version,
+	)
+}
+
+// Len returns the byte length of the encoded packet.
+func (cp *ConnectPacket) Len() int {
+	ml := cp.len()
+	return headerLen(ml) + ml
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (cp *ConnectPacket) Decode(src []byte) (int, error) {
+	total := 0
+
+	// decode header
+	hl, _, _, err := headerDecode(src[total:], CONNECT)
+	total += hl
+	if err != nil {
+		return total, err
+	}
+
+	// read protocol string
+	protoName, n, err := readLPBytes(src[total:], false, cp.Type())
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// check buffer length
+	if len(src) < total+1 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", cp.Type(), total+1, len(src))
+	}
+
+	// read version
+	versionByte := src[total]
+	total++
+
+	// check protocol string and version
+	if versionByte != Version311 && versionByte != Version31 {
+		return total, fmt.Errorf("[%s] invalid protocol version (%d)", cp.Type(), versionByte)
+	}
+
+	// set version
+	cp.Version = versionByte
+
+	// check protocol version string
+	if !bytes.Equal(protoName, version311Name) && !bytes.Equal(protoName, version31Name) {
+		return total, fmt.Errorf("[%s] invalid protocol version description (%s)", cp.Type(), protoName)
+	}
+
+	// check buffer length
+	if len(src) < total+1 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", cp.Type(), total+1, len(src))
+	}
+
+	// read connect flags
+	connectFlags := src[total]
+	total++
+
+	// read flags
+	usernameFlag := ((connectFlags >> 7) & 0x1) == 1
+	passwordFlag := ((connectFlags >> 6) & 0x1) == 1
+	willFlag := ((connectFlags >> 2) & 0x1) == 1
+	willRetain := ((connectFlags >> 5) & 0x1) == 1
+	willQOS := (connectFlags >> 3) & 0x3
+	cp.CleanSession = ((connectFlags >> 1) & 0x1) == 1
+
+	// check reserved bit
+	if connectFlags&0x1 != 0 {
+		return total, fmt.Errorf("[%s] reserved bit 0 is not 0", cp.Type())
+	}
+
+	// check will qos
+	if !validQOS(willQOS) {
+		return total, fmt.Errorf("[%s] invalid QOS level (%d) for will message", cp.Type(), willQOS)
+	}
+
+	// check will flags
+	if !willFlag && (willRetain || willQOS != 0) {
+		return total, fmt.Errorf("[%s] if the will flag (%t) is set to 0 the will qos (%d) and will retain (%t) fields must be set to zero", cp.Type(), willFlag, willQOS, willRetain)
+	}
+
+	// create will if present
+	if willFlag {
+		cp.Will = &Message{QOS: willQOS, Retain: willRetain}
+	}
+
+	// check auth flags
+	if !usernameFlag && passwordFlag {
+		return total, fmt.Errorf("[%s] password flag is set but username flag is not set", cp.Type())
+	}
+
+	// check buffer length
+	if len(src) < total+2 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", cp.Type(), total+2, len(src))
+	}
+
+	// read keep alive
+	cp.KeepAlive = binary.BigEndian.Uint16(src[total:])
+	total += 2
+
+	// read client id
+	cp.ClientID, n, err = readLPString(src[total:], cp.Type())
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// if the client supplies a zero-byte clientID, the client must also set CleanSession to 1
+	if len(cp.ClientID) == 0 && !cp.CleanSession {
+		return total, fmt.Errorf("[%s] clean session must be 1 if client id is zero length", cp.Type())
+	}
+
+	// read will topic and payload
+	if cp.Will != nil {
+		cp.Will.Topic, n, err = readLPString(src[total:], cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		cp.Will.Payload, n, err = readLPBytes(src[total:], true, cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	// read username
+	if usernameFlag {
+		cp.Username, n, err = readLPString(src[total:], cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	// read password
+	if passwordFlag {
+		cp.Password, n, err = readLPString(src[total:], cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	return total, nil
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (cp *ConnectPacket) Encode(dst []byte) (int, error) {
+	total := 0
+
+	// encode header
+	n, err := headerEncode(dst[total:], 0, cp.len(), cp.Len(), CONNECT)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// set default version byte
+	if cp.Version == 0 {
+		cp.Version = Version311
+	}
+
+	// check version byte
+	if cp.Version != Version311 && cp.Version != Version31 {
+		return total, fmt.Errorf("[%s] unsupported protocol version %d", cp.Type(), cp.Version)
+	}
+
+	// write version string, length has been checked beforehand
+	if cp.Version == Version311 {
+		n, _ = writeLPBytes(dst[total:], version311Name, cp.Type())
+		total += n
+	} else if cp.Version == Version31 {
+		n, _ = writeLPBytes(dst[total:], version31Name, cp.Type())
+		total += n
+	}
+
+	// write version value
+	dst[total] = cp.Version
+	total++
+
+	var connectFlags byte
+
+	// set username flag
+	if len(cp.Username) > 0 {
+		connectFlags |= 128 // 10000000
+	} else {
+		connectFlags &= 127 // 01111111
+	}
+
+	// set password flag
+	if len(cp.Password) > 0 {
+		connectFlags |= 64 // 01000000
+	} else {
+		connectFlags &= 191 // 10111111
+	}
+
+	// set will flag
+	if cp.Will != nil {
+		connectFlags |= 0x4 // 00000100
+
+		// check will topic length
+		if len(cp.Will.Topic) == 0 {
+			return total, fmt.Errorf("[%s] will topic is empty", cp.Type())
+		}
+
+		// check will qos
+		if !validQOS(cp.Will.QOS) {
+			return total, fmt.Errorf("[%s] invalid will qos level %d", cp.Type(), cp.Will.QOS)
+		}
+
+		// set will qos flag
+		connectFlags = (connectFlags & 231) | (cp.Will.QOS << 3) // 231 = 11100111
+
+		// set will retain flag
+		if cp.Will.Retain {
+			connectFlags |= 32 // 00100000
+		} else {
+			connectFlags &= 223 // 11011111
+		}
+
+	} else {
+		connectFlags &= 251 // 11111011
+	}
+
+	// set clean session flag
+	if cp.CleanSession {
+		connectFlags |= 0x2 // 00000010
+	} else {
+		connectFlags &= 253 // 11111101
+	}
+
+	// write connect flags
+	dst[total] = connectFlags
+	total++
+
+	// write keep alive
+	binary.BigEndian.PutUint16(dst[total:], cp.KeepAlive)
+	total += 2
+
+	// write client id
+	n, err = writeLPString(dst[total:], cp.ClientID, cp.Type())
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write will topic and payload
+	if cp.Will != nil {
+		n, err = writeLPString(dst[total:], cp.Will.Topic, cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		n, err = writeLPBytes(dst[total:], cp.Will.Payload, cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	if len(cp.Username) == 0 && len(cp.Password) > 0 {
+		return total, fmt.Errorf("[%s] password set without username", cp.Type())
+	}
+
+	// write username
+	if len(cp.Username) > 0 {
+		n, err = writeLPString(dst[total:], cp.Username, cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	// write password
+	if len(cp.Password) > 0 {
+		n, err = writeLPString(dst[total:], cp.Password, cp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	return total, nil
+}
+
+// Returns the payload length.
+func (cp *ConnectPacket) len() int {
+	total := 0
+
+	if cp.Version == Version31 {
+		// 2 bytes protocol name length
+		// 6 bytes protocol name
+		// 1 byte protocol version
+		total += 2 + 6 + 1
+	} else {
+		// 2 bytes protocol name length
+		// 4 bytes protocol name
+		// 1 byte protocol version
+		total += 2 + 4 + 1
+	}
+
+	// 1 byte connect flags
+	// 2 bytes keep alive timer
+	total += 1 + 2
+
+	// add the clientID length
+	total += 2 + len(cp.ClientID)
+
+	// add the will topic and will message length
+	if cp.Will != nil {
+		total += 2 + len(cp.Will.Topic) + 2 + len(cp.Will.Payload)
+	}
+
+	// add the username length
+	if len(cp.Username) > 0 {
+		total += 2 + len(cp.Username)
+	}
+
+	// add the password length
+	if len(cp.Password) > 0 {
+		total += 2 + len(cp.Password)
+	}
+
+	return total
+}

--- a/mqtt_packet/connect_test.go
+++ b/mqtt_packet/connect_test.go
@@ -1,0 +1,770 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectInterface(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+		Topic:   "w",
+		Payload: []byte("m"),
+		QOS:     QOSAtLeastOnce,
+	}
+
+	assert.Equal(t, pkt.Type(), CONNECT)
+	assert.Equal(t, "<ConnectPacket ClientID=\"\" KeepAlive=0 Username=\"\" Password=\"\" CleanSession=true Will=<Message Topic=\"w\" QOS=1 Retain=false Payload=[109]> Version=4>", pkt.String())
+}
+
+func TestConnectPacketDecode1(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		60,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,   // Protocol Level
+		206, // Connect Flags
+		0,   // Keep Alive MSB
+		10,  // Keep Alive LSB
+		0,   // Client ID MSB
+		7,   // Client ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // Will Topic MSB
+		4, // Will Topic LSB
+		'w', 'i', 'l', 'l',
+		0,  // Will Message MSB
+		12, // Will Message LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+		0, // Username ID MSB
+		7, // Username ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0,  // Password ID MSB
+		10, // Password ID LSB
+		'v', 'e', 'r', 'y', 's', 'e', 'c', 'r', 'e', 't',
+	}
+
+	pkt := NewConnectPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, uint16(10), pkt.KeepAlive)
+	assert.Equal(t, "surgemq", pkt.ClientID)
+	assert.Equal(t, "will", pkt.Will.Topic)
+	assert.Equal(t, []byte("send me home"), pkt.Will.Payload)
+	assert.Equal(t, "surgemq", pkt.Username)
+	assert.Equal(t, "verysecret", pkt.Password)
+	assert.Equal(t, Version311, pkt.Version)
+}
+
+func TestConnectPacketDecode2(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		60,
+		0, // Protocol String MSB
+		6, // Protocol String LSB
+		'M', 'Q', 'I', 's', 'd', 'p',
+		3,   // Protocol Level
+		206, // Connect Flags
+		0,   // Keep Alive MSB
+		10,  // Keep Alive LSB
+		0,   // Client ID MSB
+		7,   // Client ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // Will Topic MSB
+		4, // Will Topic LSB
+		'w', 'i', 'l', 'l',
+		0,  // Will Message MSB
+		12, // Will Message LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+		0, // Username ID MSB
+		7, // Username ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0,  // Password ID MSB
+		10, // Password ID LSB
+		'v', 'e', 'r', 'y', 's', 'e', 'c', 'r', 'e', 't',
+	}
+
+	pkt := NewConnectPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, uint16(10), pkt.KeepAlive)
+	assert.Equal(t, "surgemq", pkt.ClientID)
+	assert.Equal(t, "will", pkt.Will.Topic)
+	assert.Equal(t, []byte("send me home"), pkt.Will.Payload)
+	assert.Equal(t, "surgemq", pkt.Username)
+	assert.Equal(t, "verysecret", pkt.Password)
+	assert.Equal(t, Version31, pkt.Version)
+}
+
+func TestConnectPacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		60, // <- wrong remaining length
+		0,  // Protocol String MSB
+		5,  // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		5, // Protocol String LSB <- invalid size
+		'M', 'Q', 'T', 'T',
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		// Protocol Level <- missing
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError4(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		8,
+		0,                       // Protocol String MSB
+		5,                       // Protocol String LSB
+		'M', 'Q', 'T', 'T', 'X', // <- wrong protocol string
+		4,
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError5(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		5, // Protocol Level <- wrong id
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError6(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		// Connect Flags <- missing
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError7(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		1, // Connect Flags <- reserved bit set to one
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError8(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,  // Protocol Level
+		24, // Connect Flags <- invalid qos
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError9(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		8, // Connect Flags <- will flag set to zero but others not
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError10(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,  // Protocol Level
+		64, // Connect Flags <- password flag set but not username
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError11(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		0, // Connect Flags
+		0, // Keep Alive MSB <- missing
+		// Keep Alive LSB <- missing
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError12(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		7,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		0, // Connect Flags
+		0, // Keep Alive MSB
+		1, // Keep Alive LSB
+		0, // Client ID MSB
+		2, // Client ID LSB <- wrong size
+		'x',
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError13(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		0, // Connect Flags <- clean session false
+		0, // Keep Alive MSB
+		1, // Keep Alive LSB
+		0, // Client ID MSB
+		0, // Client ID LSB
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError14(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		6, // Connect Flags
+		0, // Keep Alive MSB
+		1, // Keep Alive LSB
+		0, // Client ID MSB
+		0, // Client ID LSB
+		0, // Will Topic MSB
+		1, // Will Topic LSB <- wrong size
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError15(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4, // Protocol Level
+		6, // Connect Flags
+		0, // Keep Alive MSB
+		1, // Keep Alive LSB
+		0, // Client ID MSB
+		0, // Client ID LSB
+		0, // Will Topic MSB
+		0, // Will Topic LSB
+		0, // Will Payload MSB
+		1, // Will Payload LSB <- wrong size
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError16(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,   // Protocol Level
+		194, // Connect Flags
+		0,   // Keep Alive MSB
+		1,   // Keep Alive LSB
+		0,   // Client ID MSB
+		0,   // Client ID LSB
+		0,   // Username MSB
+		1,   // Username LSB <- wrong size
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketDecodeError17(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		6,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,   // Protocol Level
+		194, // Connect Flags
+		0,   // Keep Alive MSB
+		1,   // Keep Alive LSB
+		0,   // Client ID MSB
+		0,   // Client ID LSB
+		0,   // Username MSB
+		0,   // Username LSB
+		0,   // Password MSB
+		1,   // Password LSB <- wrong size
+	}
+
+	pkt := NewConnectPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestConnectPacketEncode1(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		60,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,   // Protocol level 4
+		204, // Connect Flags
+		0,   // Keep Alive MSB
+		10,  // Keep Alive LSB
+		0,   // Client ID MSB
+		7,   // Client ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // Will Topic MSB
+		4, // Will Topic LSB
+		'w', 'i', 'l', 'l',
+		0,  // Will Message MSB
+		12, // Will Message LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+		0, // Username ID MSB
+		7, // Username ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0,  // Password ID MSB
+		10, // Password ID LSB
+		'v', 'e', 'r', 'y', 's', 'e', 'c', 'r', 'e', 't',
+	}
+
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+		QOS:     QOSAtLeastOnce,
+		Topic:   "will",
+		Payload: []byte("send me home"),
+	}
+	pkt.CleanSession = false
+	pkt.ClientID = "surgemq"
+	pkt.KeepAlive = 10
+	pkt.Username = "surgemq"
+	pkt.Password = "verysecret"
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestConnectPacketEncode2(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		14,
+		0, // Protocol String MSB
+		6, // Protocol String LSB
+		'M', 'Q', 'I', 's', 'd', 'p',
+		3,  // Protocol level 4
+		2,  // Connect Flags
+		0,  // Keep Alive MSB
+		10, // Keep Alive LSB
+		0,  // Client ID MSB
+		0,  // Client ID LSB
+	}
+
+	pkt := NewConnectPacket()
+	pkt.CleanSession = true
+	pkt.KeepAlive = 10
+	pkt.Version = Version31
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestConnectPacketEncode3(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		12,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,  // Protocol level 4
+		2,  // Connect Flags
+		0,  // Keep Alive MSB
+		10, // Keep Alive LSB
+		0,  // Client ID MSB
+		0,  // Client ID LSB
+	}
+
+	pkt := NewConnectPacket()
+	pkt.CleanSession = true
+	pkt.KeepAlive = 10
+	pkt.Version = 0
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestConnectPacketEncodeError1(t *testing.T) {
+	pkt := NewConnectPacket()
+
+	dst := make([]byte, 4) // <- too small buffer
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestConnectPacketEncodeError2(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+		Topic: "t",
+		QOS:   3, // <- wrong qos
+	}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 9, n)
+}
+
+func TestConnectPacketEncodeError3(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.ClientID = string(make([]byte, 65536)) // <- too big
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 14, n)
+}
+
+func TestConnectPacketEncodeError4(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+		Topic: string(make([]byte, 65536)), // <- too big
+	}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 16, n)
+}
+
+func TestConnectPacketEncodeError5(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+		Topic:   "t",
+		Payload: make([]byte, 65536), // <- too big
+	}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 19, n)
+}
+
+func TestConnectPacketEncodeError6(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Username = string(make([]byte, 65536)) // <- too big
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 16, n)
+}
+
+func TestConnectPacketEncodeError7(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Password = "p" // <- missing username
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 14, n)
+}
+
+func TestConnectPacketEncodeError8(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Username = "u"
+	pkt.Password = string(make([]byte, 65536)) // <- too big
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 19, n)
+}
+
+func TestConnectPacketEncodeError9(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+	// <- missing topic
+	}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 9, n)
+}
+
+func TestConnectPacketEncodeError10(t *testing.T) {
+	pkt := NewConnectPacket()
+	pkt.Version = 255
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestConnectEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		60,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,   // Protocol level 4
+		238, // Connect Flags
+		0,   // Keep Alive MSB
+		10,  // Keep Alive LSB
+		0,   // Client ID MSB
+		7,   // Client ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // Will Topic MSB
+		4, // Will Topic LSB
+		'w', 'i', 'l', 'l',
+		0,  // Will Message MSB
+		12, // Will Message LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+		0, // Username ID MSB
+		7, // Username ID LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0,  // Password ID MSB
+		10, // Password ID LSB
+		'v', 'e', 'r', 'y', 's', 'e', 'c', 'r', 'e', 't',
+	}
+
+	pkt := NewConnectPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+
+	dst := make([]byte, pkt.Len())
+	n2, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := pkt.Decode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n3)
+}
+
+func BenchmarkConnectEncode(b *testing.B) {
+	pkt := NewConnectPacket()
+	pkt.Will = &Message{
+		Topic:   "w",
+		Payload: []byte("m"),
+		QOS:     QOSAtLeastOnce,
+	}
+	pkt.CleanSession = true
+	pkt.ClientID = "i"
+	pkt.KeepAlive = 10
+	pkt.Username = "u"
+	pkt.Password = "p"
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkConnectDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(CONNECT << 4),
+		25,
+		0, // Protocol String MSB
+		4, // Protocol String LSB
+		'M', 'Q', 'T', 'T',
+		4,   // Protocol level 4
+		206, // Connect Flags
+		0,   // Keep Alive MSB
+		10,  // Keep Alive LSB
+		0,   // Client ID MSB
+		1,   // Client ID LSB
+		'i',
+		0, // Will Topic MSB
+		1, // Will Topic LSB
+		'w',
+		0, // Will Message MSB
+		1, // Will Message LSB
+		'm',
+		0, // Username ID MSB
+		1, // Username ID LSB
+		'u',
+		0, // Password ID MSB
+		1, // Password ID LSB
+		'p',
+	}
+
+	pkt := NewConnectPacket()
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/mqtt_packet/example_test.go
+++ b/mqtt_packet/example_test.go
@@ -1,0 +1,53 @@
+package packet
+
+import "fmt"
+
+func Example() {
+	/* Packet Encoding */
+
+	// Create new packet.
+	pkt1 := NewConnectPacket()
+	pkt1.Username = "gomqtt"
+	pkt1.Password = "amazing!"
+
+	// Allocate buffer.
+	buf := make([]byte, pkt1.Len())
+
+	// Encode the packet.
+	if _, err := pkt1.Encode(buf); err != nil {
+		panic(err) // error while encoding
+	}
+
+	/* Packet Decoding */
+
+	// Detect packet.
+	l, mt := DetectPacket(buf)
+
+	// Check length
+	if l == 0 {
+		return // buffer not complete yet
+	}
+
+	// Create packet.
+	pkt2, err := mt.New()
+	if err != nil {
+		panic(err) // packet type is invalid
+	}
+
+	// Decode packet.
+	_, err = pkt2.Decode(buf)
+	if err != nil {
+		panic(err) // there was an error while decoding
+	}
+
+	switch pkt2.Type() {
+	case CONNECT:
+		c := pkt2.(*ConnectPacket)
+		fmt.Println(c.Username)
+		fmt.Println(c.Password)
+	}
+
+	// Output:
+	// gomqtt
+	// amazing!
+}

--- a/mqtt_packet/header.go
+++ b/mqtt_packet/header.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const maxRemainingLength int = 268435455 // bytes, or 256 MB
+
+// Returns the length of the fixed header in bytes.
+func headerLen(rl int) int {
+	// packet type and flag byte
+	total := 1
+
+	if rl <= 127 {
+		total++
+	} else if rl <= 16383 {
+		total += 2
+	} else if rl <= 2097151 {
+		total += 3
+	} else {
+		total += 4
+	}
+
+	return total
+}
+
+// Encodes the fixed header.
+func headerEncode(dst []byte, flags byte, rl int, tl int, t Type) (int, error) {
+	total := 0
+
+	// check buffer length
+	if len(dst) < tl {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", t, tl, len(dst))
+	}
+
+	// check remaining length
+	if rl > maxRemainingLength || rl < 0 {
+		return total, fmt.Errorf("[%s] remaining length (%d) out of bound (max %d, min 0)", t, rl, maxRemainingLength)
+	}
+
+	// check header length
+	hl := headerLen(rl)
+	if len(dst) < hl {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", t, hl, len(dst))
+	}
+
+	// write type and flags
+	typeAndFlags := byte(t)<<4 | (t.defaultFlags() & 0xf)
+	typeAndFlags |= flags
+	dst[total] = typeAndFlags
+	total++
+
+	// write remaining length
+	n := binary.PutUvarint(dst[total:], uint64(rl))
+	total += n
+
+	return total, nil
+}
+
+// Decodes the fixed header.
+func headerDecode(src []byte, t Type) (int, byte, int, error) {
+	total := 0
+
+	// check buffer size
+	if len(src) < 2 {
+		return total, 0, 0, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", t, 2, len(src))
+	}
+
+	// read type and flags
+	typeAndFlags := src[total : total+1]
+	decodedType := Type(typeAndFlags[0] >> 4)
+	flags := typeAndFlags[0] & 0x0f
+	total++
+
+	// check against static type
+	if decodedType != t {
+		return total, 0, 0, fmt.Errorf("[%s] invalid type %d", t, decodedType)
+	}
+
+	// check flags except for publish packets
+	if t != PUBLISH && flags != t.defaultFlags() {
+		return total, 0, 0, fmt.Errorf("[%s] invalid flags, expected %d, got %d", t, t.defaultFlags(), flags)
+	}
+
+	// read remaining length
+	_rl, m := binary.Uvarint(src[total:])
+	rl := int(_rl)
+	total += m
+
+	// check resulting remaining length
+	if m <= 0 {
+		return total, 0, 0, fmt.Errorf("[%s] error reading remaining length", t)
+	}
+
+	// check remaining buffer
+	if rl > len(src[total:]) {
+		return total, 0, 0, fmt.Errorf("[%s] remaining length (%d) is greater than remaining buffer (%d)", t, rl, len(src[total:]))
+	}
+
+	return total, flags, rl, nil
+}

--- a/mqtt_packet/header_test.go
+++ b/mqtt_packet/header_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketHeaderDecodeError1(t *testing.T) {
+	buf := []byte{0x6f, 193, 2} // <- not enough bytes
+
+	_, _, _, err := headerDecode(buf, 0)
+	assert.Error(t, err)
+}
+
+func TestPacketHeaderDecodeError2(t *testing.T) {
+	// source to small
+	buf := []byte{0x62}
+
+	_, _, _, err := headerDecode(buf, 0)
+	assert.Error(t, err)
+}
+
+func TestPacketHeaderDecodeError3(t *testing.T) {
+	buf := []byte{0x62, 0xff} // <- invalid packet type
+
+	_, _, _, err := headerDecode(buf, 0)
+	assert.Error(t, err)
+}
+
+func TestPacketHeaderDecodeError4(t *testing.T) {
+	// remaining length to big
+	buf := []byte{0x62, 0xff, 0xff, 0xff, 0xff}
+
+	n, _, _, err := headerDecode(buf, 6)
+
+	assert.Error(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestPacketHeaderDecodeError5(t *testing.T) {
+	buf := []byte{0x66, 0x00, 0x01} // <- wrong flags
+
+	n, _, _, err := headerDecode(buf, 6)
+	assert.Error(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestPacketHeaderEncode1(t *testing.T) {
+	headerBytes := []byte{0x62, 193, 2}
+
+	buf := make([]byte, 3)
+	n, err := headerEncode(buf, 0, 321, 3, PUBREL)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, headerBytes, buf)
+}
+
+func TestPacketHeaderEncode2(t *testing.T) {
+	headerBytes := []byte{0x62, 0xff, 0xff, 0xff, 0x7f}
+
+	buf := make([]byte, 5)
+	n, err := headerEncode(buf, 0, maxRemainingLength, 5, PUBREL)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, headerBytes, buf)
+}
+
+func TestPacketHeaderEncodeError1(t *testing.T) {
+	headerBytes := []byte{0x00}
+
+	buf := make([]byte, 1) // <- wrong buffer size
+	n, err := headerEncode(buf, 0, 0, 2, PUBREL)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, headerBytes, buf)
+}
+
+func TestPacketHeaderEncodeError2(t *testing.T) {
+	headerBytes := []byte{0x00, 0x00}
+
+	buf := make([]byte, 2)
+	// overload max remaining length
+	n, err := headerEncode(buf, 0, maxRemainingLength+1, 2, PUBREL)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, headerBytes, buf)
+}
+
+func TestPacketHeaderEncodeError3(t *testing.T) {
+	headerBytes := []byte{0x00, 0x00}
+
+	buf := make([]byte, 2)
+	// too small buffer
+	n, err := headerEncode(buf, 0, 2097151, 2, PUBREL)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, headerBytes, buf)
+}

--- a/mqtt_packet/identified.go
+++ b/mqtt_packet/identified.go
@@ -1,0 +1,289 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Returns the byte length of an identified packet.
+func identifiedPacketLen() int {
+	return headerLen(2) + 2
+}
+
+// Decodes an identified packet.
+func identifiedPacketDecode(src []byte, t Type) (int, uint16, error) {
+	total := 0
+
+	// decode header
+	hl, _, rl, err := headerDecode(src, t)
+	total += hl
+	if err != nil {
+		return total, 0, err
+	}
+
+	// check remaining length
+	if rl != 2 {
+		return total, 0, fmt.Errorf("[%s] expected remaining length to be 2", t)
+	}
+
+	// read packet id
+	packetID := binary.BigEndian.Uint16(src[total:])
+	total += 2
+
+	// check packet id
+	if packetID == 0 {
+		return total, 0, fmt.Errorf("[%s] packet id must be grater than zero", t)
+	}
+
+	return total, packetID, nil
+}
+
+// Encodes an identified packet.
+func identifiedPacketEncode(dst []byte, packetID uint16, t Type) (int, error) {
+	total := 0
+
+	// check packet id
+	if packetID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", t)
+	}
+
+	// encode header
+	n, err := headerEncode(dst[total:], 0, 2, identifiedPacketLen(), t)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write packet id
+	binary.BigEndian.PutUint16(dst[total:], packetID)
+	total += 2
+
+	return total, nil
+}
+
+// A PubackPacket is the response to a PublishPacket with QOS level 1.
+type PubackPacket struct {
+	// The packet identifier.
+	PacketID uint16
+}
+
+// NewPubackPacket creates a new PubackPacket.
+func NewPubackPacket() *PubackPacket {
+	return &PubackPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PubackPacket) Type() Type {
+	return PUBACK
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PubackPacket) Len() int {
+	return identifiedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PubackPacket) Decode(src []byte) (int, error) {
+	n, pid, err := identifiedPacketDecode(src, PUBACK)
+	pp.PacketID = pid
+	return n, err
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PubackPacket) Encode(dst []byte) (int, error) {
+	return identifiedPacketEncode(dst, pp.PacketID, PUBACK)
+}
+
+// String returns a string representation of the packet.
+func (pp *PubackPacket) String() string {
+	return fmt.Sprintf("<PubackPacket PacketID=%d>", pp.PacketID)
+}
+
+// A PubcompPacket is the response to a PubrelPacket. It is the fourth and
+// final packet of the QOS 2 protocol exchange.
+type PubcompPacket struct {
+	// The packet identifier.
+	PacketID uint16
+}
+
+var _ Packet = (*PubcompPacket)(nil)
+
+// NewPubcompPacket creates a new PubcompPacket.
+func NewPubcompPacket() *PubcompPacket {
+	return &PubcompPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PubcompPacket) Type() Type {
+	return PUBCOMP
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PubcompPacket) Len() int {
+	return identifiedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PubcompPacket) Decode(src []byte) (int, error) {
+	n, pid, err := identifiedPacketDecode(src, PUBCOMP)
+	pp.PacketID = pid
+	return n, err
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PubcompPacket) Encode(dst []byte) (int, error) {
+	return identifiedPacketEncode(dst, pp.PacketID, PUBCOMP)
+}
+
+// String returns a string representation of the packet.
+func (pp *PubcompPacket) String() string {
+	return fmt.Sprintf("<PubcompPacket PacketID=%d>", pp.PacketID)
+}
+
+// A PubrecPacket is the response to a PublishPacket with QOS 2. It is the
+// second packet of the QOS 2 protocol exchange.
+type PubrecPacket struct {
+	// Shared packet identifier.
+	PacketID uint16
+}
+
+// NewPubrecPacket creates a new PubrecPacket.
+func NewPubrecPacket() *PubrecPacket {
+	return &PubrecPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PubrecPacket) Type() Type {
+	return PUBREC
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PubrecPacket) Len() int {
+	return identifiedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PubrecPacket) Decode(src []byte) (int, error) {
+	n, pid, err := identifiedPacketDecode(src, PUBREC)
+	pp.PacketID = pid
+	return n, err
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PubrecPacket) Encode(dst []byte) (int, error) {
+	return identifiedPacketEncode(dst, pp.PacketID, PUBREC)
+}
+
+// String returns a string representation of the packet.
+func (pp *PubrecPacket) String() string {
+	return fmt.Sprintf("<PubrecPacket PacketID=%d>", pp.PacketID)
+}
+
+// A PubrelPacket is the response to a PubrecPacket. It is the third packet of
+// the QOS 2 protocol exchange.
+type PubrelPacket struct {
+	// Shared packet identifier.
+	PacketID uint16
+}
+
+var _ Packet = (*PubrelPacket)(nil)
+
+// NewPubrelPacket creates a new PubrelPacket.
+func NewPubrelPacket() *PubrelPacket {
+	return &PubrelPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PubrelPacket) Type() Type {
+	return PUBREL
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PubrelPacket) Len() int {
+	return identifiedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PubrelPacket) Decode(src []byte) (int, error) {
+	n, pid, err := identifiedPacketDecode(src, PUBREL)
+	pp.PacketID = pid
+	return n, err
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PubrelPacket) Encode(dst []byte) (int, error) {
+	return identifiedPacketEncode(dst, pp.PacketID, PUBREL)
+}
+
+// String returns a string representation of the packet.
+func (pp *PubrelPacket) String() string {
+	return fmt.Sprintf("<PubrelPacket PacketID=%d>", pp.PacketID)
+}
+
+// An UnsubackPacket is sent by the server to the client to confirm receipt of
+// an UnsubscribePacket.
+type UnsubackPacket struct {
+	// Shared packet identifier.
+	PacketID uint16
+}
+
+// NewUnsubackPacket creates a new UnsubackPacket.
+func NewUnsubackPacket() *UnsubackPacket {
+	return &UnsubackPacket{}
+}
+
+// Type returns the packets type.
+func (up *UnsubackPacket) Type() Type {
+	return UNSUBACK
+}
+
+// Len returns the byte length of the encoded packet.
+func (up *UnsubackPacket) Len() int {
+	return identifiedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (up *UnsubackPacket) Decode(src []byte) (int, error) {
+	n, pid, err := identifiedPacketDecode(src, UNSUBACK)
+	up.PacketID = pid
+	return n, err
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (up *UnsubackPacket) Encode(dst []byte) (int, error) {
+	return identifiedPacketEncode(dst, up.PacketID, UNSUBACK)
+}
+
+// String returns a string representation of the packet.
+func (up *UnsubackPacket) String() string {
+	return fmt.Sprintf("<UnsubackPacket PacketID=%d>", up.PacketID)
+}

--- a/mqtt_packet/identified_test.go
+++ b/mqtt_packet/identified_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentifiedPacketDecode(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		2,
+		0, // packet ID MSB
+		7, // packet ID LSB
+	}
+
+	n, pid, err := identifiedPacketDecode(pktBytes, PUBACK)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, uint16(7), pid)
+}
+
+func TestIdentifiedPacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		1, // <- wrong remaining length
+		0, // packet ID MSB
+		7, // packet ID LSB
+	}
+
+	n, pid, err := identifiedPacketDecode(pktBytes, PUBACK)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, uint16(0), pid)
+}
+
+func TestIdentifiedPacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		2,
+		7, // packet ID LSB
+		// <- insufficient bytes
+	}
+
+	n, pid, err := identifiedPacketDecode(pktBytes, PUBACK)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, uint16(0), pid)
+}
+
+func TestIdentifiedPacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		2,
+		0, // packet ID LSB
+		0, // packet ID MSB <- zero id
+	}
+
+	n, pid, err := identifiedPacketDecode(pktBytes, PUBACK)
+
+	assert.Error(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, uint16(0), pid)
+}
+
+func TestIdentifiedPacketEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		2,
+		0, // packet ID MSB
+		7, // packet ID LSB
+	}
+
+	dst := make([]byte, identifiedPacketLen())
+	n, err := identifiedPacketEncode(dst, 7, PUBACK)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestIdentifiedPacketEncodeError1(t *testing.T) {
+	dst := make([]byte, 3) // <- insufficient buffer
+	n, err := identifiedPacketEncode(dst, 7, PUBACK)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestIdentifiedPacketEncodeError2(t *testing.T) {
+	dst := make([]byte, identifiedPacketLen())
+	n, err := identifiedPacketEncode(dst, 0, PUBACK) // <- zero id
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestIdentifiedPacketEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		2,
+		0, // packet ID MSB
+		7, // packet ID LSB
+	}
+
+	pkt := &PubackPacket{}
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+
+	dst := make([]byte, 100)
+	n2, err := identifiedPacketEncode(dst, 7, PUBACK)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, pid, err := identifiedPacketDecode(pktBytes, PUBACK)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n3)
+	assert.Equal(t, uint16(7), pid)
+}
+
+func BenchmarkIdentifiedPacketEncode(b *testing.B) {
+	pkt := &PubackPacket{}
+	pkt.PacketID = 1
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkIdentifiedPacketDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(PUBACK << 4),
+		2,
+		0, // packet ID MSB
+		1, // packet ID LSB
+	}
+
+	pkt := &PubackPacket{}
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func testIdentifiedPacketImplementation(t *testing.T, pkt Packet) {
+	assert.Equal(t, fmt.Sprintf("<%sPacket PacketID=1>", pkt.Type().String()), pkt.String())
+
+	buf := make([]byte, pkt.Len())
+	n, err := pkt.Encode(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+
+	n, err = pkt.Decode(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+}
+
+func TestPubackImplementation(t *testing.T) {
+	pkt := NewPubackPacket()
+	pkt.PacketID = 1
+
+	testIdentifiedPacketImplementation(t, pkt)
+}
+
+func TestPubcompImplementation(t *testing.T) {
+	pkt := NewPubcompPacket()
+	pkt.PacketID = 1
+
+	testIdentifiedPacketImplementation(t, pkt)
+}
+
+func TestPubrecImplementation(t *testing.T) {
+	pkt := NewPubrecPacket()
+	pkt.PacketID = 1
+
+	testIdentifiedPacketImplementation(t, pkt)
+}
+
+func TestPubrelImplementation(t *testing.T) {
+	pkt := NewPubrelPacket()
+	pkt.PacketID = 1
+
+	testIdentifiedPacketImplementation(t, pkt)
+}
+
+func TestUnsubackImplementation(t *testing.T) {
+	pkt := NewUnsubackPacket()
+	pkt.PacketID = 1
+
+	testIdentifiedPacketImplementation(t, pkt)
+}

--- a/mqtt_packet/message.go
+++ b/mqtt_packet/message.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import "fmt"
+
+// A Message bundles data that is published between brokers and clients.
+type Message struct {
+	// The Topic of the message.
+	Topic string
+
+	// The Payload of the message.
+	Payload []byte
+
+	// The QOS indicates the level of assurance for delivery.
+	QOS byte
+
+	// If the Retain flag is set to true, the server must store the message,
+	// so that it can be delivered to future subscribers whose subscriptions
+	// match its topic name.
+	Retain bool
+}
+
+// String returns a string representation of the message.
+func (m *Message) String() string {
+	return fmt.Sprintf("<Message Topic=%q QOS=%d Retain=%t Payload=%v>",
+		m.Topic, m.QOS, m.Retain, m.Payload)
+}
+
+// Copy returns a copy of the message.
+func (m Message) Copy() *Message {
+	return &m
+}

--- a/mqtt_packet/messages_test.go
+++ b/mqtt_packet/messages_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageString(t *testing.T) {
+	msg := &Message{
+		Topic:   "w",
+		Payload: []byte("m"),
+		QOS:     QOSAtLeastOnce,
+	}
+
+	assert.Equal(t, "<Message Topic=\"w\" QOS=1 Retain=false Payload=[109]>", msg.String())
+}
+
+func TestMessageCopy(t *testing.T) {
+	msg1 := &Message{
+		Topic:   "w",
+		Payload: []byte("m"),
+		QOS:     QOSAtLeastOnce,
+	}
+
+	msg2 := msg1.Copy()
+	assert.Equal(t, msg1.String(), msg2.String())
+
+	msg1.Retain = true
+	assert.False(t, msg2.Retain)
+}

--- a/mqtt_packet/naked.go
+++ b/mqtt_packet/naked.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import "fmt"
+
+// Returns the byte length of a naked packet.
+func nakedPacketLen() int {
+	return headerLen(0)
+}
+
+// Decodes a naked packet.
+func nakedPacketDecode(src []byte, t Type) (int, error) {
+	// decode header
+	hl, _, rl, err := headerDecode(src, t)
+
+	// check remaining length
+	if rl != 0 {
+		return hl, fmt.Errorf("[%s] expected zero remaining length", t)
+	}
+
+	return hl, err
+}
+
+// Encodes a naked packet.
+func nakedPacketEncode(dst []byte, t Type) (int, error) {
+	// encode header
+	return headerEncode(dst, 0, 0, nakedPacketLen(), t)
+}
+
+// A DisconnectPacket is sent from the client to the server.
+// It indicates that the client is disconnecting cleanly.
+type DisconnectPacket struct{}
+
+// NewDisconnectPacket creates a new DisconnectPacket.
+func NewDisconnectPacket() *DisconnectPacket {
+	return &DisconnectPacket{}
+}
+
+// Type returns the packets type.
+func (dp *DisconnectPacket) Type() Type {
+	return DISCONNECT
+}
+
+// Len returns the byte length of the encoded packet.
+func (dp *DisconnectPacket) Len() int {
+	return nakedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (dp *DisconnectPacket) Decode(src []byte) (int, error) {
+	return nakedPacketDecode(src, DISCONNECT)
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (dp *DisconnectPacket) Encode(dst []byte) (int, error) {
+	return nakedPacketEncode(dst, DISCONNECT)
+}
+
+// String returns a string representation of the packet.
+func (dp *DisconnectPacket) String() string {
+	return "<DisconnectPacket>"
+}
+
+// A PingreqPacket is sent from a client to the server.
+type PingreqPacket struct{}
+
+// NewPingreqPacket creates a new PingreqPacket.
+func NewPingreqPacket() *PingreqPacket {
+	return &PingreqPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PingreqPacket) Type() Type {
+	return PINGREQ
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PingreqPacket) Len() int {
+	return nakedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PingreqPacket) Decode(src []byte) (int, error) {
+	return nakedPacketDecode(src, PINGREQ)
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PingreqPacket) Encode(dst []byte) (int, error) {
+	return nakedPacketEncode(dst, PINGREQ)
+}
+
+// String returns a string representation of the packet.
+func (pp *PingreqPacket) String() string {
+	return "<PingreqPacket>"
+}
+
+// A PingrespPacket is sent by the server to the client in response to a
+// PingreqPacket. It indicates that the server is alive.
+type PingrespPacket struct{}
+
+var _ Packet = (*PingrespPacket)(nil)
+
+// NewPingrespPacket creates a new PingrespPacket.
+func NewPingrespPacket() *PingrespPacket {
+	return &PingrespPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PingrespPacket) Type() Type {
+	return PINGRESP
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PingrespPacket) Len() int {
+	return nakedPacketLen()
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PingrespPacket) Decode(src []byte) (int, error) {
+	return nakedPacketDecode(src, PINGRESP)
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PingrespPacket) Encode(dst []byte) (int, error) {
+	return nakedPacketEncode(dst, PINGRESP)
+}
+
+// String returns a string representation of the packet.
+func (pp *PingrespPacket) String() string {
+	return "<PingrespPacket>"
+}

--- a/mqtt_packet/naked_test.go
+++ b/mqtt_packet/naked_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNakedPacketDecode(t *testing.T) {
+	pktBytes := []byte{
+		byte(DISCONNECT << 4),
+		0,
+	}
+
+	n, err := nakedPacketDecode(pktBytes, DISCONNECT)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestNakedPacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(DISCONNECT << 4),
+		1, // <- wrong remaining length
+		0,
+	}
+
+	n, err := nakedPacketDecode(pktBytes, DISCONNECT)
+
+	assert.Error(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestNakedPacketEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(DISCONNECT << 4),
+		0,
+	}
+
+	dst := make([]byte, nakedPacketLen())
+	n, err := nakedPacketEncode(dst, DISCONNECT)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestNakedPacketEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(DISCONNECT << 4),
+		0,
+	}
+
+	n, err := nakedPacketDecode(pktBytes, DISCONNECT)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	dst := make([]byte, nakedPacketLen())
+	n2, err := nakedPacketEncode(dst, DISCONNECT)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := nakedPacketDecode(dst, DISCONNECT)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n3)
+}
+
+func BenchmarkNakedPacketEncode(b *testing.B) {
+	buf := make([]byte, nakedPacketLen())
+
+	for i := 0; i < b.N; i++ {
+		_, err := nakedPacketEncode(buf, DISCONNECT)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkNakedPacketDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(DISCONNECT << 4),
+		0,
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := nakedPacketDecode(pktBytes, DISCONNECT)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func testNakedPacketImplementation(t *testing.T, _t Type) {
+	pkt, err := _t.New()
+	assert.NoError(t, err)
+	assert.Equal(t, _t, pkt.Type())
+	assert.Equal(t, fmt.Sprintf("<%sPacket>", pkt.Type().String()), pkt.String())
+
+	buf := make([]byte, pkt.Len())
+	n, err := pkt.Encode(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	n, err = pkt.Decode(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestDisconnectImplementation(t *testing.T) {
+	testNakedPacketImplementation(t, DISCONNECT)
+}
+
+func TestPingreqImplementation(t *testing.T) {
+	testNakedPacketImplementation(t, PINGREQ)
+}
+
+func TestPingrespImplementation(t *testing.T) {
+	testNakedPacketImplementation(t, PINGRESP)
+}

--- a/mqtt_packet/packet.go
+++ b/mqtt_packet/packet.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package packet implements functionality for encoding and decoding MQTT 3.1.1
+// (http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/) packets.
+package packet
+
+import "encoding/binary"
+
+const (
+	// QOSAtMostOnce defines that the message is delivered at most once, or it
+	// may not be delivered at all.
+	QOSAtMostOnce byte = iota
+
+	// QOSAtLeastOnce defines that the message is always delivered at least once.
+	QOSAtLeastOnce
+
+	// QOSExactlyOnce defines that the message is always delivered exactly once.
+	QOSExactlyOnce
+
+	// QOSFailure indicates that there has been an error while subscribing
+	// to a specific topic.
+	QOSFailure = 0x80
+)
+
+// A Packet is an MQTT control packet that can be encoded to a buffer or decoded
+// from a buffer.
+type Packet interface {
+	// Type returns the packets type.
+	Type() Type
+
+	// Len returns the byte length of the encoded packet.
+	Len() int
+
+	// Decode reads from the byte slice argument. It returns the total number of
+	// bytes decoded, and whether there have been any errors during the process.
+	Decode(src []byte) (int, error)
+
+	// Encode writes the packet bytes into the byte slice from the argument. It
+	// returns the number of bytes encoded and whether there's any errors along
+	// the way. If there is an error, the byte slice should be considered invalid.
+	Encode(dst []byte) (int, error)
+
+	// String returns a string representation of the packet.
+	String() string
+}
+
+// DetectPacket tries to detect the next packet in a buffer. It returns a length
+// greater than zero if the packet has been detected as well as its Type.
+func DetectPacket(src []byte) (int, Type) {
+	// check for minimum size
+	if len(src) < 2 {
+		return 0, 0
+	}
+
+	// get type
+	t := Type(src[0] >> 4)
+
+	// get remaining length
+	_rl, n := binary.Uvarint(src[1:])
+	rl := int(_rl)
+
+	if n <= 0 {
+		return 0, 0
+	}
+
+	return 1 + n + rl, t
+}
+
+// PacketID checks the packets type and returns its PacketID and true, or if it
+// does not have a PacketID, zero and false.
+func PacketID(packet Packet) (uint16, bool) {
+	switch packet.Type() {
+	case PUBLISH:
+		return packet.(*PublishPacket).PacketID, true
+	case PUBACK:
+		return packet.(*PubackPacket).PacketID, true
+	case PUBREC:
+		return packet.(*PubrecPacket).PacketID, true
+	case PUBREL:
+		return packet.(*PubrelPacket).PacketID, true
+	case PUBCOMP:
+		return packet.(*PubcompPacket).PacketID, true
+	case SUBSCRIBE:
+		return packet.(*SubscribePacket).PacketID, true
+	case SUBACK:
+		return packet.(*SubackPacket).PacketID, true
+	case UNSUBSCRIBE:
+		return packet.(*UnsubscribePacket).PacketID, true
+	case UNSUBACK:
+		return packet.(*UnsubackPacket).PacketID, true
+	}
+
+	return 0, false
+}
+
+// Fuzz is a basic fuzzing test that works with https://github.com/dvyukov/go-fuzz:
+//
+//		$ go-fuzz-build github.com/gomqtt/packet
+//		$ go-fuzz -bin=./packet-fuzz.zip -workdir=./fuzz
+func Fuzz(data []byte) int {
+	// check for zero length data
+	if len(data) == 0 {
+		return 1
+	}
+
+	// Detect packet.
+	_, mt := DetectPacket(data)
+
+	// For testing purposes we will not cancel
+	// on incomplete buffers
+
+	// Create a new packet
+	pkt, err := mt.New()
+	if err != nil {
+		return 0
+	}
+
+	// Decode it from the buffer.
+	_, err = pkt.Decode(data)
+	if err != nil {
+		return 0
+	}
+
+	// Everything was ok!
+	return 1
+}

--- a/mqtt_packet/packet_test.go
+++ b/mqtt_packet/packet_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQOSCodes(t *testing.T) {
+	assert.Equal(t, byte(0), QOSAtMostOnce)
+	assert.Equal(t, byte(1), QOSAtLeastOnce)
+	assert.Equal(t, byte(2), QOSExactlyOnce)
+}
+
+func TestFixedHeaderFlags(t *testing.T) {
+	type detail struct {
+		name  string
+		flags byte
+	}
+
+	details := map[Type]detail{
+		CONNECT:     {"Connect", 0},
+		CONNACK:     {"Connack", 0},
+		PUBLISH:     {"Publish", 0},
+		PUBACK:      {"Puback", 0},
+		PUBREC:      {"Pubrec", 0},
+		PUBREL:      {"Pubrel", 2},
+		PUBCOMP:     {"Pubcomp", 0},
+		SUBSCRIBE:   {"Subscribe", 2},
+		SUBACK:      {"Suback", 0},
+		UNSUBSCRIBE: {"Unsubscribe", 2},
+		UNSUBACK:    {"Unsuback", 0},
+		PINGREQ:     {"Pingreq", 0},
+		PINGRESP:    {"Pingresp", 0},
+		DISCONNECT:  {"Disconnect", 0},
+	}
+
+	for m, d := range details {
+		if m.String() != d.name {
+			t.Errorf("Expected %s, got %s", d.name, m)
+		}
+
+		if m.defaultFlags() != d.flags {
+			t.Errorf("Expected %d, got %d", d.flags, m.defaultFlags())
+		}
+	}
+}
+
+func TestDetect1(t *testing.T) {
+	buf := []byte{0x10, 0x0}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 2, l)
+	assert.Equal(t, 1, int(_t))
+}
+
+func TestDetect2(t *testing.T) {
+	// not enough bytes
+	buf := []byte{0x10, 0xff}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 0, l)
+	assert.Equal(t, 0, int(_t))
+}
+
+func TestDetect3(t *testing.T) {
+	buf := []byte{0x10, 0xff, 0x0}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 130, l)
+	assert.Equal(t, 1, int(_t))
+}
+
+func TestDetect4(t *testing.T) {
+	// not enough bytes
+	buf := []byte{0x10, 0xff, 0xff}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 0, l)
+	assert.Equal(t, 0, int(_t))
+}
+
+func TestDetect5(t *testing.T) {
+	buf := []byte{0x10, 0xff, 0xff, 0xff, 0x7f}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 268435460, l)
+	assert.Equal(t, 1, int(_t))
+}
+
+func TestDetect6(t *testing.T) {
+	buf := []byte{0x10}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 0, l)
+	assert.Equal(t, 0, int(_t))
+}
+
+func TestDetect7(t *testing.T) {
+	buf := []byte{0x10, 0xff, 0xff, 0xff, 0x80}
+
+	l, _t := DetectPacket(buf)
+
+	assert.Equal(t, 0, l)
+	assert.Equal(t, 0, int(_t))
+}
+
+func TestPacketID(t *testing.T) {
+	type detail struct {
+		packet Packet
+		ok     bool
+	}
+
+	details := map[Type]detail{
+		CONNECT:     {NewConnectPacket(), false},
+		CONNACK:     {NewConnackPacket(), false},
+		PUBLISH:     {NewPublishPacket(), true},
+		PUBACK:      {NewPubackPacket(), true},
+		PUBREC:      {NewPubrecPacket(), true},
+		PUBREL:      {NewPubrelPacket(), true},
+		PUBCOMP:     {NewPubcompPacket(), true},
+		SUBSCRIBE:   {NewSubscribePacket(), true},
+		SUBACK:      {NewSubackPacket(), true},
+		UNSUBSCRIBE: {NewUnsubscribePacket(), true},
+		UNSUBACK:    {NewUnsubackPacket(), true},
+		PINGREQ:     {NewPingreqPacket(), false},
+		PINGRESP:    {NewPingrespPacket(), false},
+		DISCONNECT:  {NewDisconnectPacket(), false},
+	}
+
+	for _, d := range details {
+		_, ok := PacketID(d.packet)
+		assert.Equal(t, d.ok, ok)
+	}
+}
+
+func TestFuzz(t *testing.T) {
+	// too small buffer
+	assert.Equal(t, 1, Fuzz([]byte{}))
+
+	// wrong packet type
+	b1 := []byte{0 << 4, 0x00}
+	assert.Equal(t, 0, Fuzz(b1))
+
+	// wrong packet format
+	b2 := []byte{2 << 4, 0x02, 0x00, 0x06}
+	assert.Equal(t, 0, Fuzz(b2))
+
+	// right packet format
+	b3 := []byte{2 << 4, 0x02, 0x00, 0x01}
+	assert.Equal(t, 1, Fuzz(b3))
+}

--- a/mqtt_packet/publish.go
+++ b/mqtt_packet/publish.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// A PublishPacket is sent from a client to a server or from server to a client
+// to transport an application message.
+type PublishPacket struct {
+	// The message to publish.
+	Message Message
+
+	// If the Dup flag is set to false, it indicates that this is the first
+	// occasion that the client or server has attempted to send this
+	// PublishPacket. If the dup flag is set to true, it indicates that this
+	// might be re-delivery of an earlier attempt to send the Packet.
+	Dup bool
+
+	// The packet identifier.
+	PacketID uint16
+}
+
+// NewPublishPacket creates a new PublishPacket.
+func NewPublishPacket() *PublishPacket {
+	return &PublishPacket{}
+}
+
+// Type returns the packets type.
+func (pp *PublishPacket) Type() Type {
+	return PUBLISH
+}
+
+// String returns a string representation of the packet.
+func (pp *PublishPacket) String() string {
+	return fmt.Sprintf("<PublishPacket PacketID=%d Message=%s Dup=%t>",
+		pp.PacketID, pp.Message.String(), pp.Dup)
+}
+
+// Len returns the byte length of the encoded packet.
+func (pp *PublishPacket) Len() int {
+	ml := pp.len()
+	return headerLen(ml) + ml
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (pp *PublishPacket) Decode(src []byte) (int, error) {
+	total := 0
+
+	// decode header
+	hl, flags, rl, err := headerDecode(src[total:], PUBLISH)
+	total += hl
+	if err != nil {
+		return total, err
+	}
+
+	// read flags
+	pp.Dup = ((flags >> 3) & 0x1) == 1
+	pp.Message.Retain = (flags & 0x1) == 1
+	pp.Message.QOS = (flags >> 1) & 0x3
+
+	// check qos
+	if !validQOS(pp.Message.QOS) {
+		return total, fmt.Errorf("[%s] invalid QOS level (%d)", pp.Type(), pp.Message.QOS)
+	}
+
+	// check buffer length
+	if len(src) < total+2 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", pp.Type(), total+2, len(src))
+	}
+
+	n := 0
+
+	// read topic
+	pp.Message.Topic, n, err = readLPString(src[total:], pp.Type())
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	if pp.Message.QOS != 0 {
+		// check buffer length
+		if len(src) < total+2 {
+			return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", pp.Type(), total+2, len(src))
+		}
+
+		// read packet id
+		pp.PacketID = binary.BigEndian.Uint16(src[total:])
+		total += 2
+
+		// check packet id
+		if pp.PacketID == 0 {
+			return total, fmt.Errorf("[%s] packet id must be grater than zero", pp.Type())
+		}
+	}
+
+	// calculate payload length
+	l := int(rl) - (total - hl)
+
+	// read payload
+	if l > 0 {
+		pp.Message.Payload = make([]byte, l)
+		copy(pp.Message.Payload, src[total:total+l])
+		total += len(pp.Message.Payload)
+	}
+
+	return total, nil
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (pp *PublishPacket) Encode(dst []byte) (int, error) {
+	total := 0
+
+	// check topic length
+	if len(pp.Message.Topic) == 0 {
+		return total, fmt.Errorf("[%s] topic name is empty", pp.Type())
+	}
+
+	flags := byte(0)
+
+	// set dup flag
+	if pp.Dup {
+		flags |= 0x8 // 00001000
+	} else {
+		flags &= 247 // 11110111
+	}
+
+	// set retain flag
+	if pp.Message.Retain {
+		flags |= 0x1 // 00000001
+	} else {
+		flags &= 254 // 11111110
+	}
+
+	// check qos
+	if !validQOS(pp.Message.QOS) {
+		return 0, fmt.Errorf("[%s] invalid QOS level %d", pp.Type(), pp.Message.QOS)
+	}
+
+	// check packet id
+	if pp.Message.QOS > 0 && pp.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", pp.Type())
+	}
+
+	// set qos
+	flags = (flags & 249) | (pp.Message.QOS << 1) // 249 = 11111001
+
+	// encode header
+	n, err := headerEncode(dst[total:], flags, pp.len(), pp.Len(), PUBLISH)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write topic
+	n, err = writeLPString(dst[total:], pp.Message.Topic, pp.Type())
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write packet id
+	if pp.Message.QOS != 0 {
+		binary.BigEndian.PutUint16(dst[total:], pp.PacketID)
+		total += 2
+	}
+
+	// write payload
+	copy(dst[total:], pp.Message.Payload)
+	total += len(pp.Message.Payload)
+
+	return total, nil
+}
+
+// Returns the payload length.
+func (pp *PublishPacket) len() int {
+	total := 2 + len(pp.Message.Topic) + len(pp.Message.Payload)
+	if pp.Message.QOS != 0 {
+		total += 2
+	}
+
+	return total
+}

--- a/mqtt_packet/publish_test.go
+++ b/mqtt_packet/publish_test.go
@@ -1,0 +1,334 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublishInterface(t *testing.T) {
+	pkt := NewPublishPacket()
+
+	assert.Equal(t, pkt.Type(), PUBLISH)
+	assert.Equal(t, "<PublishPacket PacketID=0 Message=<Message Topic=\"\" QOS=0 Retain=false Payload=[]> Dup=false>", pkt.String())
+}
+
+func TestPublishPacketDecode1(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 11,
+		23,
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // packet ID MSB
+		7, // packet ID LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+	}
+
+	pkt := NewPublishPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, uint16(7), pkt.PacketID)
+	assert.Equal(t, "surgemq", pkt.Message.Topic)
+	assert.Equal(t, []byte("send me home"), pkt.Message.Payload)
+	assert.Equal(t, uint8(1), pkt.Message.QOS)
+	assert.Equal(t, true, pkt.Message.Retain)
+	assert.Equal(t, true, pkt.Dup)
+}
+
+func TestPublishPacketDecode2(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH << 4),
+		21,
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+	}
+
+	pkt := NewPublishPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, uint16(0), pkt.PacketID)
+	assert.Equal(t, "surgemq", pkt.Message.Topic)
+	assert.Equal(t, []byte("send me home"), pkt.Message.Payload)
+	assert.Equal(t, uint8(0), pkt.Message.QOS)
+	assert.Equal(t, false, pkt.Message.Retain)
+	assert.Equal(t, false, pkt.Dup)
+}
+
+func TestPublishPacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH << 4),
+		2, // <- too much
+	}
+
+	pkt := NewPublishPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 6, // <- wrong qos
+		0,
+	}
+
+	pkt := NewPublishPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH << 4),
+		0,
+		// <- missing topic stuff
+	}
+
+	pkt := NewPublishPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketDecodeError4(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH << 4),
+		2,
+		0, // topic name MSB
+		1, // topic name LSB
+		// <- missing topic string
+	}
+
+	pkt := NewPublishPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketDecodeError5(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 2,
+		2,
+		0, // topic name MSB
+		1, // topic name LSB
+		't',
+		// <- missing packet id
+	}
+
+	pkt := NewPublishPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketDecodeError6(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 2,
+		2,
+		0, // topic name MSB
+		1, // topic name LSB
+		't',
+		0,
+		0, // <- zero packet id
+	}
+
+	pkt := NewPublishPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketEncode1(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 11,
+		23,
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // packet ID MSB
+		7, // packet ID LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+	}
+
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "surgemq"
+	pkt.Message.QOS = QOSAtLeastOnce
+	pkt.Message.Retain = true
+	pkt.Dup = true
+	pkt.PacketID = 7
+	pkt.Message.Payload = []byte("send me home")
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestPublishPacketEncode2(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH << 4),
+		21,
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+	}
+
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "surgemq"
+	pkt.Message.Payload = []byte("send me home")
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestPublishPacketEncodeError1(t *testing.T) {
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "" // <- empty topic
+
+	dst := make([]byte, pkt.Len())
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketEncodeError2(t *testing.T) {
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "t"
+	pkt.Message.QOS = 3 // <- wrong qos
+
+	dst := make([]byte, pkt.Len())
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketEncodeError3(t *testing.T) {
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "t"
+
+	dst := make([]byte, 1) // <- too small
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketEncodeError4(t *testing.T) {
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = string(make([]byte, 65536)) // <- too big
+
+	dst := make([]byte, pkt.Len())
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestPublishPacketEncodeError5(t *testing.T) {
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "test"
+	pkt.Message.QOS = 1
+	pkt.PacketID = 0 // <- zero packet id
+
+	dst := make([]byte, pkt.Len())
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestPublishEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 2,
+		23,
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // packet ID MSB
+		7, // packet ID LSB
+		's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'h', 'o', 'm', 'e',
+	}
+
+	pkt := NewPublishPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+
+	dst := make([]byte, pkt.Len())
+	n2, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := pkt.Decode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n3)
+}
+
+func BenchmarkPublishEncode(b *testing.B) {
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "t"
+	pkt.Message.QOS = QOSAtLeastOnce
+	pkt.PacketID = 1
+	pkt.Message.Payload = []byte("p")
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkPublishDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(PUBLISH<<4) | 2,
+		6,
+		0, // topic name MSB
+		1, // topic name LSB
+		't',
+		0, // packet ID MSB
+		1, // packet ID LSB
+		'p',
+	}
+
+	pkt := NewPublishPacket()
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/mqtt_packet/stream.go
+++ b/mqtt_packet/stream.go
@@ -1,0 +1,154 @@
+package packet
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+)
+
+// ErrDetectionOverflow is returned by the Decoder if the next packet couldn't
+// be detect from the initial header bytes.
+var ErrDetectionOverflow = errors.New("detection overflow")
+
+// ErrReadLimitExceeded can be returned during a Receive if the connection
+// exceeded its read limit.
+//
+// Note: this error is wrapped in an Error with a NetworkError code.
+var ErrReadLimitExceeded = errors.New("read limit exceeded")
+
+// An Encoder wraps a Writer and continuously encodes packets.
+type Encoder struct {
+	writer *bufio.Writer
+	buffer bytes.Buffer
+}
+
+// NewEncoder creates a new Encoder.
+func NewEncoder(writer io.Writer) *Encoder {
+	return &Encoder{
+		writer: bufio.NewWriter(writer),
+	}
+}
+
+// Write encodes and writes the passed packet to the write buffer.
+func (e *Encoder) Write(pkt Packet) error {
+	// reset and eventually grow buffer
+	packetLength := pkt.Len()
+	e.buffer.Reset()
+	e.buffer.Grow(packetLength)
+	buf := e.buffer.Bytes()[0:packetLength]
+
+	// encode packet
+	_, err := pkt.Encode(buf)
+	if err != nil {
+		return err
+	}
+
+	// write buffer
+	_, err = e.writer.Write(buf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Flush flushes the writer buffer.
+func (e *Encoder) Flush() error {
+	return e.writer.Flush()
+}
+
+// A Decoder wraps a Reader and continuously decodes packets.
+type Decoder struct {
+	Limit int64
+
+	reader *bufio.Reader
+	buffer bytes.Buffer
+}
+
+// NewDecoder returns a new Decoder.
+func NewDecoder(reader io.Reader) *Decoder {
+	return &Decoder{
+		reader: bufio.NewReader(reader),
+	}
+}
+
+// Read reads the next packet from the buffered reader.
+func (d *Decoder) Read() (Packet, error) {
+	// initial detection length
+	detectionLength := 2
+
+	for {
+		// check length
+		if detectionLength > 5 {
+			return nil, ErrDetectionOverflow
+		}
+
+		// try read detection bytes
+		header, err := d.reader.Peek(detectionLength)
+		if err == io.EOF && len(header) != 0 {
+			// an EOF with some data is unexpected
+			return nil, io.ErrUnexpectedEOF
+		} else if err != nil {
+			return nil, err
+		}
+
+		// detect packet
+		packetLength, packetType := DetectPacket(header)
+
+		// on zero packet length:
+		// increment detection length and try again
+		if packetLength <= 0 {
+			detectionLength++
+			continue
+		}
+
+		// check read limit
+		if d.Limit > 0 && int64(packetLength) > d.Limit {
+			return nil, ErrReadLimitExceeded
+		}
+
+		// create packet
+		pkt, err := packetType.New()
+		if err != nil {
+			return nil, err
+		}
+
+		// reset and eventually grow buffer
+		d.buffer.Reset()
+		d.buffer.Grow(packetLength)
+		buf := d.buffer.Bytes()[0:packetLength]
+
+		// read whole packet (will not return EOF)
+		_, err = io.ReadFull(d.reader, buf)
+		if err != nil {
+			return nil, err
+		}
+
+		// decode buffer
+		_, err = pkt.Decode(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		return pkt, nil
+	}
+}
+
+// A Stream combines an Encoder and Decoder
+type Stream struct {
+	Decoder
+	Encoder
+}
+
+// NewStream creates a new Stream.
+func NewStream(reader io.Reader, writer io.Writer) *Stream {
+	return &Stream{
+		Decoder: Decoder{
+			reader: bufio.NewReader(reader),
+		},
+		Encoder: Encoder{
+			writer: bufio.NewWriter(writer),
+		},
+	}
+}

--- a/mqtt_packet/stream_test.go
+++ b/mqtt_packet/stream_test.go
@@ -1,0 +1,159 @@
+package packet
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncoder(t *testing.T) {
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(buf)
+
+	err := enc.Write(NewConnectPacket())
+	assert.NoError(t, err)
+
+	err = enc.Flush()
+	assert.NoError(t, err)
+
+	assert.Len(t, buf.Bytes(), 14)
+}
+
+func TestEncoderEncodeError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(buf)
+
+	pkt := NewConnackPacket()
+	pkt.ReturnCode = 11 // <- invalid return code
+
+	err := enc.Write(pkt)
+	assert.Error(t, err)
+}
+
+func TestEncoderWriterError(t *testing.T) {
+	enc := NewEncoder(&errorWriter{
+		err: errors.New("foo"),
+	})
+
+	pkt := NewPublishPacket()
+	pkt.Message.Topic = "foo"
+	pkt.Message.Payload = make([]byte, 4096)
+
+	err := enc.Write(pkt)
+	assert.Error(t, err)
+}
+
+func TestDecoder(t *testing.T) {
+	buf := new(bytes.Buffer)
+	dec := NewDecoder(buf)
+
+	var pkt Packet = NewConnectPacket()
+	b := make([]byte, pkt.Len())
+	pkt.Encode(b)
+	buf.Write(b)
+
+	pkt, err := dec.Read()
+	assert.NoError(t, err)
+	assert.NotNil(t, pkt)
+}
+
+func TestDecoderDetectionOverflowError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	dec := NewDecoder(buf)
+
+	buf.Write([]byte{0x10, 0xff, 0xff, 0xff, 0x80})
+
+	pkt, err := dec.Read()
+	assert.Equal(t, ErrDetectionOverflow, err)
+	assert.Nil(t, pkt)
+}
+
+func TestDecoderPeekUnexpectedEOFError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	dec := NewDecoder(buf)
+
+	buf.Write([]byte{0x10, 0xff, 0xff})
+
+	pkt, err := dec.Read()
+	assert.Equal(t, io.ErrUnexpectedEOF, err)
+	assert.Nil(t, pkt)
+}
+
+func TestDecoderPeekError(t *testing.T) {
+	dec := NewDecoder(&errorReader{
+		err: errors.New("foo"),
+	})
+
+	pkt, err := dec.Read()
+	assert.Error(t, err)
+	assert.Nil(t, pkt)
+}
+
+func TestDecoderInvalidTypeError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	dec := NewDecoder(buf)
+
+	buf.Write([]byte{0x00, 0x00})
+
+	pkt, err := dec.Read()
+	assert.Contains(t, err.Error(), "invalid packet type")
+	assert.Nil(t, pkt)
+}
+
+func TestDecoderReadLimitError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	dec := NewDecoder(buf)
+	dec.Limit = 1
+
+	buf.Write([]byte{0x00, 0x00})
+
+	pkt, err := dec.Read()
+	assert.Equal(t, ErrReadLimitExceeded, err)
+	assert.Nil(t, pkt)
+}
+
+func TestDecoderReadError(t *testing.T) {
+	dec := NewDecoder(&errorReader{
+		reader: bytes.NewBuffer([]byte{0x10, 0xc, 0x0, 0x4}),
+		after:  1,
+		err:    errors.New("foo"),
+	})
+
+	pkt, err := dec.Read()
+	assert.Error(t, err)
+	assert.Nil(t, pkt)
+}
+
+func TestDecoderDecodeError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	dec := NewDecoder(buf)
+
+	buf.Write([]byte{0x20, 0x02, 0x40, 0x00})
+
+	pkt, err := dec.Read()
+	assert.Error(t, err)
+	assert.Nil(t, pkt)
+}
+
+func TestStream(t *testing.T) {
+	in := new(bytes.Buffer)
+	out := new(bytes.Buffer)
+
+	s := NewStream(in, out)
+
+	err := s.Write(NewConnectPacket())
+	assert.NoError(t, err)
+
+	err = s.Flush()
+	assert.NoError(t, err)
+
+	_, err = io.Copy(in, out)
+	assert.NoError(t, err)
+
+	pkt, err := s.Read()
+	assert.NotNil(t, pkt)
+	assert.NoError(t, err)
+}

--- a/mqtt_packet/strings.go
+++ b/mqtt_packet/strings.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const maxLPLength uint16 = 65535
+
+// read length prefixed bytes
+func readLPBytes(buf []byte, safe bool, t Type) ([]byte, int, error) {
+	if len(buf) < 2 {
+		return nil, 0, fmt.Errorf("[%s] insufficient buffer size, expected 2, got %d", t, len(buf))
+	}
+
+	n, total := 0, 0
+
+	n = int(binary.BigEndian.Uint16(buf))
+	total += 2
+	total += n
+
+	if len(buf) < total {
+		return nil, total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", t, total, len(buf))
+	}
+
+	// copy buffer in safe mode
+	if safe {
+		newBuf := make([]byte, total-2)
+		copy(newBuf, buf[2:total])
+		return newBuf, total, nil
+	}
+
+	return buf[2:total], total, nil
+}
+
+// read length prefixed string
+func readLPString(buf []byte, t Type) (string, int, error) {
+	if len(buf) < 2 {
+		return "", 0, fmt.Errorf("[%s] insufficient buffer size, expected 2, got %d", t, len(buf))
+	}
+
+	n, total := 0, 0
+
+	n = int(binary.BigEndian.Uint16(buf))
+	total += 2
+	total += n
+
+	if len(buf) < total {
+		return "", total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", t, total, len(buf))
+	}
+
+	return string(buf[2:total]), total, nil
+}
+
+// write length prefixed bytes
+func writeLPBytes(buf []byte, b []byte, t Type) (int, error) {
+	total, n := 0, len(b)
+
+	if n > int(maxLPLength) {
+		return 0, fmt.Errorf("[%s] length (%d) greater than %d bytes", t, n, maxLPLength)
+	}
+
+	if len(buf) < 2+n {
+		return 0, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", t, 2+n, len(buf))
+	}
+
+	binary.BigEndian.PutUint16(buf, uint16(n))
+	total += 2
+
+	copy(buf[total:], b)
+	total += n
+
+	return total, nil
+}
+
+// write length prefixed string
+func writeLPString(buf []byte, str string, t Type) (int, error) {
+	return writeLPBytes(buf, []byte(str), t)
+}
+
+// checks the QOS value to see if it's valid
+func validQOS(qos byte) bool {
+	return qos == QOSAtMostOnce || qos == QOSAtLeastOnce || qos == QOSExactlyOnce
+}

--- a/mqtt_packet/strings_test.go
+++ b/mqtt_packet/strings_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	testStrings = []string{
+		"this is a test",
+		"hope it succeeds",
+		"but just in case",
+		"send me your millions",
+		"",
+	}
+
+	testBytes = []byte{
+		0x0, 0xe, 't', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't',
+		0x0, 0x10, 'h', 'o', 'p', 'e', ' ', 'i', 't', ' ', 's', 'u', 'c', 'c', 'e', 'e', 'd', 's',
+		0x0, 0x10, 'b', 'u', 't', ' ', 'j', 'u', 's', 't', ' ', 'i', 'n', ' ', 'c', 'a', 's', 'e',
+		0x0, 0x15, 's', 'e', 'n', 'd', ' ', 'm', 'e', ' ', 'y', 'o', 'u', 'r', ' ', 'm', 'i', 'l', 'l', 'i', 'o', 'n', 's',
+		0x0, 0x0,
+	}
+)
+
+func TestReadLPBytes(t *testing.T) {
+	total := 0
+
+	for _, str := range testStrings {
+		b, n, err := readLPBytes(testBytes[total:], true, CONNECT)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []byte(str), b)
+		assert.Equal(t, len(str)+2, n)
+
+		total += n
+	}
+}
+
+func TestReadLPBytesErrors(t *testing.T) {
+	_, _, err := readLPBytes([]byte{}, true, CONNECT)
+	assert.Error(t, err)
+
+	_, _, err = readLPBytes([]byte{0xff, 0xff, 0xff, 0xff}, true, CONNECT)
+	assert.Error(t, err)
+}
+
+func TestReadLPStringErrors(t *testing.T) {
+	_, _, err := readLPString([]byte{}, CONNECT)
+	assert.Error(t, err)
+
+	_, _, err = readLPString([]byte{0xff, 0xff, 0xff, 0xff}, CONNECT)
+	assert.Error(t, err)
+}
+
+func TestWriteLPBytes(t *testing.T) {
+	total := 0
+	buf := make([]byte, 127)
+
+	for _, str := range testStrings {
+		n, err := writeLPBytes(buf[total:], []byte(str), CONNECT)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 2+len(str), n)
+
+		total += n
+	}
+
+	assert.Equal(t, testBytes, buf[:total])
+}
+
+func TestWriteLPBytesErrors(t *testing.T) {
+	_, err := writeLPBytes([]byte{}, make([]byte, 65536), CONNECT)
+	assert.Error(t, err)
+
+	_, err = writeLPBytes([]byte{}, make([]byte, 10), CONNECT)
+	assert.Error(t, err)
+}

--- a/mqtt_packet/suback.go
+++ b/mqtt_packet/suback.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// A SubackPacket is sent by the server to the client to confirm receipt and
+// processing of a SubscribePacket. The SubackPacket contains a list of return
+// codes, that specify the maximum QOS levels that have been granted.
+type SubackPacket struct {
+	// The granted QOS levels for the requested subscriptions.
+	ReturnCodes []uint8
+
+	// The packet identifier.
+	PacketID uint16
+}
+
+// NewSubackPacket creates a new SubackPacket.
+func NewSubackPacket() *SubackPacket {
+	return &SubackPacket{}
+}
+
+// Type returns the packets type.
+func (sp *SubackPacket) Type() Type {
+	return SUBACK
+}
+
+// String returns a string representation of the packet.
+func (sp *SubackPacket) String() string {
+	var codes []string
+
+	for _, c := range sp.ReturnCodes {
+		codes = append(codes, fmt.Sprintf("%d", c))
+	}
+
+	return fmt.Sprintf("<SubackPacket PacketID=%d ReturnCodes=[%s]>",
+		sp.PacketID, strings.Join(codes, ", "))
+}
+
+// Len returns the byte length of the encoded packet.
+func (sp *SubackPacket) Len() int {
+	ml := sp.len()
+	return headerLen(ml) + ml
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (sp *SubackPacket) Decode(src []byte) (int, error) {
+	total := 0
+
+	// decode header
+	hl, _, rl, err := headerDecode(src[total:], SUBACK)
+	total += hl
+	if err != nil {
+		return total, err
+	}
+
+	// check buffer length
+	if len(src) < total+2 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", sp.Type(), total+2, len(src))
+	}
+
+	// check remaining length
+	if rl <= 2 {
+		return total, fmt.Errorf("[%s] expected remaining length to be greater than 2, got %d", sp.Type(), rl)
+	}
+
+	// read packet id
+	sp.PacketID = binary.BigEndian.Uint16(src[total:])
+	total += 2
+
+	// check packet id
+	if sp.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", sp.Type())
+	}
+
+	// calculate number of return codes
+	rcl := int(rl) - 2
+
+	// read return codes
+	sp.ReturnCodes = make([]uint8, rcl)
+	copy(sp.ReturnCodes, src[total:total+rcl])
+	total += len(sp.ReturnCodes)
+
+	// validate return codes
+	for i, code := range sp.ReturnCodes {
+		if !validQOS(code) && code != QOSFailure {
+			return total, fmt.Errorf("[%s] invalid return code %d for topic %d", sp.Type(), code, i)
+		}
+	}
+
+	return total, nil
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (sp *SubackPacket) Encode(dst []byte) (int, error) {
+	total := 0
+
+	// check return codes
+	for i, code := range sp.ReturnCodes {
+		if !validQOS(code) && code != QOSFailure {
+			return total, fmt.Errorf("[%s] invalid return code %d for topic %d", sp.Type(), code, i)
+		}
+	}
+
+	// check packet id
+	if sp.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", sp.Type())
+	}
+
+	// encode header
+	n, err := headerEncode(dst[total:], 0, sp.len(), sp.Len(), SUBACK)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write packet id
+	binary.BigEndian.PutUint16(dst[total:], sp.PacketID)
+	total += 2
+
+	// write return codes
+	copy(dst[total:], sp.ReturnCodes)
+	total += len(sp.ReturnCodes)
+
+	return total, nil
+}
+
+// Returns the payload length.
+func (sp *SubackPacket) len() int {
+	return 2 + len(sp.ReturnCodes)
+}

--- a/mqtt_packet/suback_test.go
+++ b/mqtt_packet/suback_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubackInterface(t *testing.T) {
+	pkt := NewSubackPacket()
+	pkt.ReturnCodes = []byte{0, 1}
+
+	assert.Equal(t, pkt.Type(), SUBACK)
+	assert.Equal(t, "<SubackPacket PacketID=0 ReturnCodes=[0, 1]>", pkt.String())
+}
+
+func TestSubackPacketDecode(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		6,
+		0,    // packet ID MSB
+		7,    // packet ID LSB
+		0,    // return code 1
+		1,    // return code 2
+		2,    // return code 3
+		0x80, // return code 4
+	}
+
+	pkt := NewSubackPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, 4, len(pkt.ReturnCodes))
+}
+
+func TestSubackPacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		1, // <- wrong remaining length
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // return code 1
+	}
+
+	pkt := NewSubackPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubackPacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		6,
+		0,    // packet ID MSB
+		7,    // packet ID LSB
+		0,    // return code 1
+		1,    // return code 2
+		2,    // return code 3
+		0x81, // <- wrong return code
+	}
+
+	pkt := NewSubackPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubackPacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		1, // <- wrong remaining length
+		0, // packet ID MSB
+	}
+
+	pkt := NewSubackPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubackPacketDecodeError4(t *testing.T) {
+	pktBytes := []byte{
+		byte(PUBCOMP << 4), // <- wrong packet type
+		3,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // return code 1
+	}
+
+	pkt := NewSubackPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubackPacketDecodeError5(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		3,
+		0, // packet ID MSB
+		0, // packet ID LSB <- zero packet id
+		0,
+	}
+
+	pkt := NewSubackPacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubackPacketEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		6,
+		0,    // packet ID MSB
+		7,    // packet ID LSB
+		0,    // return code 1
+		1,    // return code 2
+		2,    // return code 3
+		0x80, // return code 4
+	}
+
+	pkt := NewSubackPacket()
+	pkt.PacketID = 7
+	pkt.ReturnCodes = []byte{0, 1, 2, 0x80}
+
+	dst := make([]byte, 10)
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestSubackPacketEncodeError1(t *testing.T) {
+	pkt := NewSubackPacket()
+	pkt.PacketID = 7
+	pkt.ReturnCodes = []byte{0x81}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestSubackPacketEncodeError2(t *testing.T) {
+	pkt := NewSubackPacket()
+	pkt.PacketID = 7
+	pkt.ReturnCodes = []byte{0x80}
+
+	dst := make([]byte, pkt.Len()-1)
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestSubackPacketEncodeError3(t *testing.T) {
+	pkt := NewSubackPacket()
+	pkt.PacketID = 0 // <- zero packet id
+	pkt.ReturnCodes = []byte{0x80}
+
+	dst := make([]byte, pkt.Len()-1)
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestSubackEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		6,
+		0,    // packet ID MSB
+		7,    // packet ID LSB
+		0,    // return code 1
+		1,    // return code 2
+		2,    // return code 3
+		0x80, // return code 4
+	}
+
+	pkt := NewSubackPacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+
+	dst := make([]byte, 100)
+	n2, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := pkt.Decode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n3)
+}
+
+func BenchmarkSubackEncode(b *testing.B) {
+	pkt := NewSubackPacket()
+	pkt.PacketID = 1
+	pkt.ReturnCodes = []byte{0}
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkSubackDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(SUBACK << 4),
+		3,
+		0, // packet ID MSB
+		1, // packet ID LSB
+		0, // return code 1
+	}
+
+	pkt := NewSubackPacket()
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/mqtt_packet/subscribe.go
+++ b/mqtt_packet/subscribe.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// A Subscription is a single subscription in a SubscribePacket.
+type Subscription struct {
+	// The topic to subscribe.
+	Topic string
+
+	// The requested maximum QOS level.
+	QOS uint8
+}
+
+func (s *Subscription) String() string {
+	return fmt.Sprintf("%q=>%d", s.Topic, s.QOS)
+}
+
+// A SubscribePacket is sent from the client to the server to create one or
+// more Subscriptions. The server will forward application messages that match
+// these subscriptions using PublishPackets.
+type SubscribePacket struct {
+	// The subscriptions.
+	Subscriptions []Subscription
+
+	// The packet identifier.
+	PacketID uint16
+}
+
+// NewSubscribePacket creates a new SUBSCRIBE packet.
+func NewSubscribePacket() *SubscribePacket {
+	return &SubscribePacket{}
+}
+
+// Type returns the packets type.
+func (sp *SubscribePacket) Type() Type {
+	return SUBSCRIBE
+}
+
+// String returns a string representation of the packet.
+func (sp *SubscribePacket) String() string {
+	var subscriptions []string
+
+	for _, t := range sp.Subscriptions {
+		subscriptions = append(subscriptions, t.String())
+	}
+
+	return fmt.Sprintf("<SubscribePacket PacketID=%d Subscriptions=[%s]>",
+		sp.PacketID, strings.Join(subscriptions, ", "))
+}
+
+// Len returns the byte length of the encoded packet.
+func (sp *SubscribePacket) Len() int {
+	ml := sp.len()
+	return headerLen(ml) + ml
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (sp *SubscribePacket) Decode(src []byte) (int, error) {
+	total := 0
+
+	// decode header
+	hl, _, rl, err := headerDecode(src[total:], SUBSCRIBE)
+	total += hl
+	if err != nil {
+		return total, err
+	}
+
+	// check buffer length
+	if len(src) < total+2 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", sp.Type(), total+2, len(src))
+	}
+
+	// read packet id
+	sp.PacketID = binary.BigEndian.Uint16(src[total:])
+	total += 2
+
+	// check packet id
+	if sp.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", sp.Type())
+	}
+
+	// reset subscriptions
+	sp.Subscriptions = sp.Subscriptions[:0]
+
+	// calculate number of subscriptions
+	sl := int(rl) - 2
+
+	for sl > 0 {
+		// read topic
+		t, n, err := readLPString(src[total:], sp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		// check buffer length
+		if len(src) < total+1 {
+			return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", sp.Type(), total+1, len(src))
+		}
+
+		// read qos and add subscription
+		sp.Subscriptions = append(sp.Subscriptions, Subscription{t, src[total]})
+		total++
+
+		// decrement counter
+		sl = sl - n - 1
+	}
+
+	// check for empty subscription list
+	if len(sp.Subscriptions) == 0 {
+		return total, fmt.Errorf("[%s] empty subscription list", sp.Type())
+	}
+
+	return total, nil
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (sp *SubscribePacket) Encode(dst []byte) (int, error) {
+	total := 0
+
+	// check packet id
+	if sp.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", sp.Type())
+	}
+
+	// encode header
+	n, err := headerEncode(dst[total:], 0, sp.len(), sp.Len(), SUBSCRIBE)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write packet it
+	binary.BigEndian.PutUint16(dst[total:], sp.PacketID)
+	total += 2
+
+	for _, t := range sp.Subscriptions {
+		// write topic
+		n, err := writeLPString(dst[total:], t.Topic, sp.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		// write qos
+		dst[total] = t.QOS
+
+		total++
+	}
+
+	return total, nil
+}
+
+// Returns the payload length.
+func (sp *SubscribePacket) len() int {
+	// packet ID
+	total := 2
+
+	for _, t := range sp.Subscriptions {
+		total += 2 + len(t.Topic) + 1
+	}
+
+	return total
+}

--- a/mqtt_packet/subscribe_test.go
+++ b/mqtt_packet/subscribe_test.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscribeInterface(t *testing.T) {
+	pkt := NewSubscribePacket()
+	pkt.Subscriptions = []Subscription{
+		{Topic: "foo", QOS: QOSAtMostOnce},
+		{Topic: "bar", QOS: QOSAtLeastOnce},
+	}
+
+	assert.Equal(t, pkt.Type(), SUBSCRIBE)
+	assert.Equal(t, "<SubscribePacket PacketID=0 Subscriptions=[\"foo\"=>0, \"bar\"=>1]>", pkt.String())
+}
+
+func TestSubscribePacketDecode(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		36,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // QOS
+		0, // topic name MSB
+		8, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c',
+		1,  // QOS
+		0,  // topic name MSB
+		10, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c', 'd', 'd',
+		2, // QOS
+	}
+
+	pkt := NewSubscribePacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, 3, len(pkt.Subscriptions))
+	assert.Equal(t, "surgemq", pkt.Subscriptions[0].Topic)
+	assert.Equal(t, uint8(0), pkt.Subscriptions[0].QOS)
+	assert.Equal(t, "/a/b/#/c", pkt.Subscriptions[1].Topic)
+	assert.Equal(t, uint8(1), pkt.Subscriptions[1].QOS)
+	assert.Equal(t, "/a/b/#/cdd", pkt.Subscriptions[2].Topic)
+	assert.Equal(t, uint8(2), pkt.Subscriptions[2].QOS)
+}
+
+func TestSubscribePacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		9, // <- too much
+	}
+
+	pkt := NewSubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		0,
+		// <- missing packet id
+	}
+
+	pkt := NewSubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		2,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		// <- missing subscription
+	}
+
+	pkt := NewSubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketDecodeError4(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		5,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		2, // topic name LSB <- wrong size
+		's',
+	}
+
+	pkt := NewSubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketDecodeError5(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		5,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		1, // topic name LSB
+		's',
+		// <- missing qos
+	}
+
+	pkt := NewSubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketDecodeError6(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		5,
+		0, // packet ID MSB
+		0, // packet ID LSB <- zero packet id
+		0, // topic name MSB
+		1, // topic name LSB
+		's',
+		0,
+	}
+
+	pkt := NewSubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		36,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // QOS
+		0, // topic name MSB
+		8, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c',
+		1,  // QOS
+		0,  // topic name MSB
+		10, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c', 'd', 'd',
+		2, // QOS
+	}
+
+	pkt := NewSubscribePacket()
+	pkt.PacketID = 7
+	pkt.Subscriptions = []Subscription{
+		{"surgemq", 0},
+		{"/a/b/#/c", 1},
+		{"/a/b/#/cdd", 2},
+	}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst)
+}
+
+func TestSubscribePacketEncodeError1(t *testing.T) {
+	pkt := NewSubscribePacket()
+	pkt.PacketID = 7
+
+	dst := make([]byte, 1) // <- too small
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketEncodeError2(t *testing.T) {
+	pkt := NewSubscribePacket()
+	pkt.PacketID = 7
+	pkt.Subscriptions = []Subscription{
+		{string(make([]byte, 65536)), 0}, // too big
+	}
+
+	dst := make([]byte, pkt.Len())
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribePacketEncodeError3(t *testing.T) {
+	pkt := NewSubscribePacket()
+	pkt.PacketID = 0 // <- zero packet id
+
+	dst := make([]byte, pkt.Len())
+	_, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+}
+
+func TestSubscribeEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		36,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // QOS
+		0, // topic name MSB
+		8, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c',
+		1,  // QOS
+		0,  // topic name MSB
+		10, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c', 'd', 'd',
+		2, // QOS
+	}
+
+	pkt := NewSubscribePacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+
+	dst := make([]byte, pkt.Len())
+	n2, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := pkt.Decode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n3)
+}
+
+func BenchmarkSubscribeEncode(b *testing.B) {
+	pkt := NewSubscribePacket()
+	pkt.PacketID = 7
+	pkt.Subscriptions = []Subscription{
+		{"t", 0},
+	}
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkSubscribeDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(SUBSCRIBE<<4) | 2,
+		6,
+		0, // packet ID MSB
+		1, // packet ID LSB
+		0, // topic name MSB
+		1, // topic name LSB
+		't',
+		0, // QOS
+	}
+
+	pkt := NewSubscribePacket()
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/mqtt_packet/type.go
+++ b/mqtt_packet/type.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import "fmt"
+
+// Type represents the MQTT packet types.
+type Type byte
+
+// All packet types.
+const (
+	_ Type = iota
+	CONNECT
+	CONNACK
+	PUBLISH
+	PUBACK
+	PUBREC
+	PUBREL
+	PUBCOMP
+	SUBSCRIBE
+	SUBACK
+	UNSUBSCRIBE
+	UNSUBACK
+	PINGREQ
+	PINGRESP
+	DISCONNECT
+)
+
+// String returns the type as a string.
+func (t Type) String() string {
+	switch t {
+	case CONNECT:
+		return "Connect"
+	case CONNACK:
+		return "Connack"
+	case PUBLISH:
+		return "Publish"
+	case PUBACK:
+		return "Puback"
+	case PUBREC:
+		return "Pubrec"
+	case PUBREL:
+		return "Pubrel"
+	case PUBCOMP:
+		return "Pubcomp"
+	case SUBSCRIBE:
+		return "Subscribe"
+	case SUBACK:
+		return "Suback"
+	case UNSUBSCRIBE:
+		return "Unsubscribe"
+	case UNSUBACK:
+		return "Unsuback"
+	case PINGREQ:
+		return "Pingreq"
+	case PINGRESP:
+		return "Pingresp"
+	case DISCONNECT:
+		return "Disconnect"
+	}
+
+	return "Unknown"
+}
+
+// DefaultFlags returns the default flag values for the packet type, as defined
+// by the MQTT spec, except for PUBLISH.
+func (t Type) defaultFlags() byte {
+	switch t {
+	case CONNECT:
+		return 0
+	case CONNACK:
+		return 0
+	case PUBACK:
+		return 0
+	case PUBREC:
+		return 0
+	case PUBREL:
+		return 2 // 00000010
+	case PUBCOMP:
+		return 0
+	case SUBSCRIBE:
+		return 2 // 00000010
+	case SUBACK:
+		return 0
+	case UNSUBSCRIBE:
+		return 2 // 00000010
+	case UNSUBACK:
+		return 0
+	case PINGREQ:
+		return 0
+	case PINGRESP:
+		return 0
+	case DISCONNECT:
+		return 0
+	}
+
+	return 0
+}
+
+// New creates a new packet based on the type. It is a shortcut to call one of
+// the New*Packet functions. An error is returned if the type is invalid.
+func (t Type) New() (Packet, error) {
+	switch t {
+	case CONNECT:
+		return NewConnectPacket(), nil
+	case CONNACK:
+		return NewConnackPacket(), nil
+	case PUBLISH:
+		return NewPublishPacket(), nil
+	case PUBACK:
+		return NewPubackPacket(), nil
+	case PUBREC:
+		return NewPubrecPacket(), nil
+	case PUBREL:
+		return NewPubrelPacket(), nil
+	case PUBCOMP:
+		return NewPubcompPacket(), nil
+	case SUBSCRIBE:
+		return NewSubscribePacket(), nil
+	case SUBACK:
+		return NewSubackPacket(), nil
+	case UNSUBSCRIBE:
+		return NewUnsubscribePacket(), nil
+	case UNSUBACK:
+		return NewUnsubackPacket(), nil
+	case PINGREQ:
+		return NewPingreqPacket(), nil
+	case PINGRESP:
+		return NewPingrespPacket(), nil
+	case DISCONNECT:
+		return NewDisconnectPacket(), nil
+	}
+
+	return nil, fmt.Errorf("[Unknown] invalid packet type %d", t)
+}
+
+// Valid returns a boolean indicating whether the type is valid or not.
+func (t Type) Valid() bool {
+	return t >= CONNECT && t <= DISCONNECT
+}

--- a/mqtt_packet/type_test.go
+++ b/mqtt_packet/type_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTypes(t *testing.T) {
+	if CONNECT != 1 ||
+		CONNACK != 2 ||
+		PUBLISH != 3 ||
+		PUBACK != 4 ||
+		PUBREC != 5 ||
+		PUBREL != 6 ||
+		PUBCOMP != 7 ||
+		SUBSCRIBE != 8 ||
+		SUBACK != 9 ||
+		UNSUBSCRIBE != 10 ||
+		UNSUBACK != 11 ||
+		PINGREQ != 12 ||
+		PINGRESP != 13 ||
+		DISCONNECT != 14 {
+
+		t.Errorf("Types have invalid code")
+	}
+}
+
+func TestTypeString(t *testing.T) {
+	assert.Equal(t, "Unknown", Type(99).String())
+}
+
+func TestTypeValid(t *testing.T) {
+	assert.True(t, CONNECT.Valid())
+}
+
+func TestTypeNew(t *testing.T) {
+	list := []Type{
+		CONNECT,
+		CONNACK,
+		PUBLISH,
+		PUBACK,
+		PUBREC,
+		PUBREL,
+		PUBCOMP,
+		SUBSCRIBE,
+		SUBACK,
+		UNSUBSCRIBE,
+		UNSUBACK,
+		PINGREQ,
+		PINGRESP,
+		DISCONNECT,
+	}
+
+	for _, _t := range list {
+		m, err := _t.New()
+		assert.NotNil(t, m)
+		assert.NoError(t, err)
+	}
+}

--- a/mqtt_packet/unsubscribe.go
+++ b/mqtt_packet/unsubscribe.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// An UnsubscribePacket is sent by the client to the server.
+type UnsubscribePacket struct {
+	// The topics to unsubscribe from.
+	Topics []string
+
+	// The packet identifier.
+	PacketID uint16
+}
+
+// NewUnsubscribePacket creates a new UnsubscribePacket.
+func NewUnsubscribePacket() *UnsubscribePacket {
+	return &UnsubscribePacket{}
+}
+
+// Type returns the packets type.
+func (up *UnsubscribePacket) Type() Type {
+	return UNSUBSCRIBE
+}
+
+// String returns a string representation of the packet.
+func (up *UnsubscribePacket) String() string {
+	var topics []string
+
+	for _, t := range up.Topics {
+		topics = append(topics, fmt.Sprintf("%q", t))
+	}
+
+	return fmt.Sprintf("<UnsubscribePacket Topics=[%s]>",
+		strings.Join(topics, ", "))
+}
+
+// Len returns the byte length of the encoded packet.
+func (up *UnsubscribePacket) Len() int {
+	ml := up.len()
+	return headerLen(ml) + ml
+}
+
+// Decode reads from the byte slice argument. It returns the total number of
+// bytes decoded, and whether there have been any errors during the process.
+func (up *UnsubscribePacket) Decode(src []byte) (int, error) {
+	total := 0
+
+	// decode header
+	hl, _, rl, err := headerDecode(src[total:], UNSUBSCRIBE)
+	total += hl
+	if err != nil {
+		return total, err
+	}
+
+	// check buffer length
+	if len(src) < total+2 {
+		return total, fmt.Errorf("[%s] insufficient buffer size, expected %d, got %d", up.Type(), total+2, len(src))
+	}
+
+	// read packet id
+	up.PacketID = binary.BigEndian.Uint16(src[total:])
+	total += 2
+
+	// check packet id
+	if up.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", up.Type())
+	}
+
+	// prepare counter
+	tl := int(rl) - 2
+
+	// reset topics
+	up.Topics = up.Topics[:0]
+
+	for tl > 0 {
+		// read topic
+		t, n, err := readLPString(src[total:], up.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+
+		// append to list
+		up.Topics = append(up.Topics, t)
+
+		// decrement counter
+		tl = tl - n - 1
+	}
+
+	// check for empty list
+	if len(up.Topics) == 0 {
+		return total, fmt.Errorf("[%s] empty topic list", up.Type())
+	}
+
+	return total, nil
+}
+
+// Encode writes the packet bytes into the byte slice from the argument. It
+// returns the number of bytes encoded and whether there's any errors along
+// the way. If there is an error, the byte slice should be considered invalid.
+func (up *UnsubscribePacket) Encode(dst []byte) (int, error) {
+	total := 0
+
+	// check packet id
+	if up.PacketID == 0 {
+		return total, fmt.Errorf("[%s] packet id must be grater than zero", up.Type())
+	}
+
+	// encode header
+	n, err := headerEncode(dst[total:], 0, up.len(), up.Len(), UNSUBSCRIBE)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// write packet id
+	binary.BigEndian.PutUint16(dst[total:], up.PacketID)
+	total += 2
+
+	for _, t := range up.Topics {
+		// write topic
+		n, err := writeLPString(dst[total:], t, up.Type())
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	return total, nil
+}
+
+// Returns the payload length.
+func (up *UnsubscribePacket) len() int {
+	// packet ID
+	total := 2
+
+	for _, t := range up.Topics {
+		total += 2 + len(t)
+	}
+
+	return total
+}

--- a/mqtt_packet/unsubscribe_test.go
+++ b/mqtt_packet/unsubscribe_test.go
@@ -1,0 +1,275 @@
+// Copyright (c) 2014 The gomqtt Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsubscribeInterface(t *testing.T) {
+	pkt := NewUnsubscribePacket()
+	pkt.Topics = []string{"foo", "bar"}
+
+	assert.Equal(t, pkt.Type(), UNSUBSCRIBE)
+	assert.Equal(t, "<UnsubscribePacket Topics=[\"foo\", \"bar\"]>", pkt.String())
+}
+
+func TestUnsubscribePacketDecode(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		33,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // topic name MSB
+		8, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c',
+		0,  // topic name MSB
+		10, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c', 'd', 'd',
+	}
+
+	pkt := NewUnsubscribePacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, 3, len(pkt.Topics))
+	assert.Equal(t, "surgemq", pkt.Topics[0])
+	assert.Equal(t, "/a/b/#/c", pkt.Topics[1])
+	assert.Equal(t, "/a/b/#/cdd", pkt.Topics[2])
+}
+
+func TestUnsubscribePacketDecodeError1(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		2,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		// empty topic list
+	}
+
+	pkt := NewUnsubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestUnsubscribePacketDecodeError2(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		6, // <- wrong remaining length
+		0, // packet ID MSB
+		7, // packet ID LSB
+	}
+
+	pkt := NewUnsubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestUnsubscribePacketDecodeError3(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		0,
+		// missing packet id
+	}
+
+	pkt := NewUnsubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestUnsubscribePacketDecodeError4(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		11,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		9, // topic name LSB <- wrong size
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+	}
+
+	pkt := NewUnsubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestUnsubscribePacketDecodeError5(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		11,
+		0, // packet ID MSB
+		0, // packet ID LSB <- zero packet id
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+	}
+
+	pkt := NewUnsubscribePacket()
+	_, err := pkt.Decode(pktBytes)
+
+	assert.Error(t, err)
+}
+
+func TestUnsubscribePacketEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		33,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // topic name MSB
+		8, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c',
+		0,  // topic name MSB
+		10, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c', 'd', 'd',
+	}
+
+	pkt := NewUnsubscribePacket()
+	pkt.PacketID = 7
+	pkt.Topics = []string{
+		"surgemq",
+		"/a/b/#/c",
+		"/a/b/#/cdd",
+	}
+
+	dst := make([]byte, 100)
+	n, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+	assert.Equal(t, pktBytes, dst[:n])
+}
+
+func TestUnsubscribePacketEncodeError1(t *testing.T) {
+	pkt := NewUnsubscribePacket()
+	pkt.PacketID = 7
+	pkt.Topics = []string{"surgemq"}
+
+	dst := make([]byte, 1) // <- too small
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestUnsubscribePacketEncodeError2(t *testing.T) {
+	pkt := NewUnsubscribePacket()
+	pkt.PacketID = 7
+	pkt.Topics = []string{string(make([]byte, 65536))}
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 6, n)
+}
+
+func TestUnsubscribePacketEncodeError3(t *testing.T) {
+	pkt := NewUnsubscribePacket()
+	pkt.PacketID = 0 // <- zero packet id
+
+	dst := make([]byte, pkt.Len())
+	n, err := pkt.Encode(dst)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, n)
+}
+
+// test to ensure encoding and decoding are the same
+// decode, encode, and decode again
+func TestUnsubscribeEqualDecodeEncode(t *testing.T) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		33,
+		0, // packet ID MSB
+		7, // packet ID LSB
+		0, // topic name MSB
+		7, // topic name LSB
+		's', 'u', 'r', 'g', 'e', 'm', 'q',
+		0, // topic name MSB
+		8, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c',
+		0,  // topic name MSB
+		10, // topic name LSB
+		'/', 'a', '/', 'b', '/', '#', '/', 'c', 'd', 'd',
+	}
+
+	pkt := NewUnsubscribePacket()
+	n, err := pkt.Decode(pktBytes)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n)
+
+	dst := make([]byte, 100)
+	n2, err := pkt.Encode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n2)
+	assert.Equal(t, pktBytes, dst[:n2])
+
+	n3, err := pkt.Decode(dst)
+
+	assert.NoError(t, err)
+	assert.Equal(t, len(pktBytes), n3)
+}
+
+func BenchmarkUnsubscribeEncode(b *testing.B) {
+	pkt := NewUnsubscribePacket()
+	pkt.PacketID = 1
+	pkt.Topics = []string{"t"}
+
+	buf := make([]byte, pkt.Len())
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Encode(buf)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkUnsubscribeDecode(b *testing.B) {
+	pktBytes := []byte{
+		byte(UNSUBSCRIBE<<4) | 2,
+		5,
+		0, // packet ID MSB
+		1, // packet ID LSB
+		0, // topic name MSB
+		1, // topic name LSB
+		't',
+	}
+
+	pkt := NewUnsubscribePacket()
+
+	for i := 0; i < b.N; i++ {
+		_, err := pkt.Decode(pktBytes)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/mqtt_packet/utils_test.go
+++ b/mqtt_packet/utils_test.go
@@ -1,0 +1,32 @@
+package packet
+
+import "io"
+
+type errorWriter struct {
+	writer io.Writer
+	after  int
+	err    error
+}
+
+func (w *errorWriter) Write(p []byte) (int, error) {
+	if w.after == 0 {
+		return 0, w.err
+	}
+
+	return w.writer.Write(p)
+}
+
+type errorReader struct {
+	reader io.Reader
+	after  int
+	err    error
+}
+
+func (r *errorReader) Read(p []byte) (int, error) {
+	if r.after == 0 {
+		return 0, r.err
+	}
+
+	r.after--
+	return r.reader.Read(p)
+}


### PR DESCRIPTION
The MQTT code originally depends on `github.com/gomqtt/packet`

However, the repo https://github.com/gomqtt has just been killed. Looks like the maintainer wants to make it part of a giant gomqtt package.

Since we only use a small part of gomqtt, I "forked" the `packet` package by making a local copy. Do you see any issue in doing this?