### PR TITLE
Added support for system commands on SDK

### DIFF
--- a/core.go
+++ b/core.go
@@ -132,8 +132,9 @@ type (
 
 	// DeviceCommand represents a command received from the MODE cloud.
 	DeviceCommand struct {
-		Action  string
-		payload json.RawMessage
+		Action  string          `json:"action"`
+		Payload json.RawMessage `json:"parameters"`
+		system  bool
 	}
 
 	// DeviceEvent represents an event to be sent to the MODE cloud.
@@ -242,10 +243,10 @@ func (dc *DeviceContext) GetInfo() (*DeviceInfo, error) {
 }
 
 func (cmd *DeviceCommand) String() string {
-	if cmd.payload == nil {
+	if cmd.Payload == nil {
 		return fmt.Sprintf("{Action:\"%s\"}", cmd.Action)
 	} else {
-		return fmt.Sprintf("{Action:\"%s\", Parameters:%s}", cmd.Action, string(cmd.payload))
+		return fmt.Sprintf("{Action:\"%s\", Parameters:%s}", cmd.Action, string(cmd.Payload))
 	}
 }
 
@@ -263,10 +264,10 @@ func decodeOpaqueJSON(b []byte, v interface{}) error {
 
 // BindParameters maps the command parameters from JSON to the provided struct.
 func (cmd *DeviceCommand) BindParameters(v interface{}) error {
-	if cmd.payload == nil {
+	if cmd.Payload == nil {
 		// nothing to do.
 		return nil
 	}
 
-	return json.Unmarshal(cmd.payload, v)
+	return json.Unmarshal(cmd.Payload, v)
 }

--- a/mqtt_test.go
+++ b/mqtt_test.go
@@ -1,0 +1,63 @@
+package mode
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	packet "github.com/moderepo/device-sdk-go/mqtt_packet"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	mqttTest MqttTestDaemon = MqttTestDaemon{
+		TestPort:     9998,
+		WriteChannel: make(chan packet.PublishPacket, 1),
+		ExitChannel:  make(chan bool, 1),
+		Results:      map[string]string{},
+	}
+)
+
+func init() {
+	SetMQTTHostPort("localhost", mqttTest.TestPort, false)
+}
+
+func TestMqtt(t *testing.T) {
+	// Fake server to capture event
+	go mqttTest.Start()
+
+	dc := &DeviceContext{
+		DeviceID:  0,             // change this to real device ID
+		AuthToken: "XXXXXXXXXXX", // change this to real API key assigned to device
+	}
+
+	cmdQueue := make(chan *DeviceCommand, commandQueueLength)
+	evtQueue := make(chan *DeviceEvent, eventQueueLength)
+	bulkDataQueue := make(chan *DeviceBulkData, bulkDataQueueLength)
+	syncQueue := make(chan *keyValueSync, keyValueSyncQueueLength)
+	pushQueue := make(chan *keyValueSync, keyValuePushQueueLength)
+	evtQueue <- &DeviceEvent{EventType: "", qos: QOSAtLeastOnce}
+	conn, err := dc.openMQTTConn(cmdQueue, evtQueue, bulkDataQueue, syncQueue, pushQueue)
+	fmt.Println("OpenMQTTConn err:", err)
+	if err != nil {
+		mqttTest.ShutDown()
+		return
+	}
+	payloadStr := `{"action":"blah", "parameters":{"a":"b"}}`
+	payload := bytes.NewBufferString(payloadStr).Bytes()
+	mqttTest.WriteChannel <- packet.PublishPacket{
+		Message: packet.Message{
+			Topic:   "/devices/0/systemcommand",
+			Payload: payload,
+			QOS:     packet.QOSAtLeastOnce,
+		},
+		PacketID: 10,
+	}
+	fmt.Println("wrote into WriteChannel")
+	time.Sleep(time.Second * 10)
+	conn.close()
+	fmt.Println("connection is closed")
+	mqttTest.ShutDown()
+	assert.Equal(t, 2, 2)
+}

--- a/mqtttestdaemon.go
+++ b/mqtttestdaemon.go
@@ -1,0 +1,139 @@
+package mode
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	packet "github.com/moderepo/device-sdk-go/mqtt_packet"
+)
+
+type MqttTestDaemon struct {
+	TestPort     int
+	WG           sync.WaitGroup
+	WaitOn       map[string]bool
+	WriteChannel chan packet.PublishPacket
+	ExitChannel  chan bool
+	Results      map[string]string
+}
+
+func (m *MqttTestDaemon) Reset() {
+	m.WaitOn = map[string]bool{}
+	m.Results = map[string]string{}
+}
+
+func (m *MqttTestDaemon) readStream(conn net.Conn) bool {
+	println("\n[MqttTestDaemon]readStream starts")
+	defer func() {
+		println("\n[MqttTestDaemon] readStream ends")
+	}()
+	for {
+		tmp := make([]byte, 256)
+		n, err := conn.Read(tmp)
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println("[MqttTestDaemon] read error:", err)
+			}
+			break
+		}
+		l, ty := packet.DetectPacket(tmp[0:n])
+		var pkt packet.Packet
+		var pub *packet.PublishPacket = nil
+		if ty == packet.CONNECT {
+			pkt = &packet.ConnackPacket{ReturnCode: packet.ConnectionAccepted}
+		} else if ty == packet.SUBSCRIBE {
+			pkt = &packet.SubackPacket{PacketID: 1, ReturnCodes: []byte{packet.QOSAtMostOnce, packet.QOSAtMostOnce, packet.QOSAtMostOnce}}
+		} else if ty == packet.PUBLISH {
+			pub = packet.NewPublishPacket()
+			pub.Decode(tmp[0:n])
+			pkt = &packet.PubackPacket{PacketID: pub.PacketID}
+		} else {
+			fmt.Println("[MqttTestDaemon] tcp buffer:", l, ty)
+			break
+		}
+
+		dst := make([]byte, 100)
+		n2, err := pkt.Encode(dst)
+		if err != nil {
+			fmt.Println("[MqttTestDaemon] encode error:", err)
+			break
+		}
+		if _, err = conn.Write(dst[0:n2]); err != nil {
+			fmt.Println("Write error:", err)
+			break
+		}
+		if pub != nil {
+			m.Results["PubMessage"] = pub.Message.String()
+			m.Results["PubTopic"] = pub.Message.Topic
+			if _, ok := m.WaitOn["pub"]; ok {
+				m.WG.Done()
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MqttTestDaemon) writeStream(conn net.Conn) bool {
+	println("\n[MqttTestDaemon] writeStream starts")
+	defer func() {
+		println("\n[MqttTestDaemon] writeStream ends")
+	}()
+
+	for {
+		select {
+		case pkt := <-m.WriteChannel:
+			dst := make([]byte, 100)
+			n, err := pkt.Encode(dst)
+			if err != nil {
+				fmt.Println("[MqttTestDaemon] Encode error:", err)
+				return false
+			}
+			if _, err = conn.Write(dst[0:n]); err != nil {
+				fmt.Println("[MqttTestDaemon] Write error:", err)
+				return false
+			}
+			if _, ok := m.WaitOn["writeStream"]; ok {
+				m.WG.Done()
+			}
+		default:
+			return true
+		}
+	}
+	return true
+}
+
+func (m *MqttTestDaemon) Start() {
+	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", m.TestPort))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		l.Close()
+		println("[MqttTestDaemon] loop has ended")
+	}()
+
+	for {
+		select {
+		case e := <-m.ExitChannel:
+			println("\n[MqttTestDaemon] Closing", e)
+			return
+		default:
+			println("[MqttTestDaemon] looping")
+		}
+		conn, err := l.Accept()
+		if err != nil {
+			continue
+		}
+		m.readStream(conn)
+		m.writeStream(conn)
+		conn.Close()
+	}
+	return
+}
+
+func (m *MqttTestDaemon) ShutDown() {
+	println("[MqttTestDaemon] Shutdowning")
+	m.ExitChannel <- true
+}


### PR DESCRIPTION
- Added support for system commands on SDK
- Listens to a system topic from Mode Cloud.  
- Client must implement function to use the system calls.  
- There are no default system functions.  If not implemented, the behavior is ignored.