### PR TITLE
feat: Support Smart Module request/response for v2.

### DIFF
--- a/core.go
+++ b/core.go
@@ -59,8 +59,8 @@ var (
 	errorLogger = log.New(os.Stderr, "[MODE - ERROR] ", log.LstdFlags)
 
 	// For publishing device events to cloud.
-	deviceEventRetryInterval    = time.Second * 15
-	syncedBulkDataRetryInterval = time.Second * 15
+	deviceEventTimeout    = time.Second * 15
+	syncedBulkDataTimeout = time.Second * 30
 
 	// For publishing key-value events to cloud.
 	maxKeyValueUpdateAttempts   uint = 3
@@ -109,14 +109,14 @@ func SetErrorLogger(l *log.Logger) {
 // device event sender. These config parameters are used when sending device
 // events with QoS1 (at least once).
 func ConfigureDeviceEventSender(_ uint, retryInterval time.Duration) {
-	deviceEventRetryInterval = retryInterval
+	deviceEventTimeout = retryInterval
 }
 
 // ConfigureDeviceEventTimeout overrides the default parameters used by the
 // timeout of device event sender. These config parameters are used when sending device
 // events with QoS1 (at least once).
 func ConfigureDeviceEventTimeout(retryInterval time.Duration) {
-	deviceEventRetryInterval = retryInterval
+	deviceEventTimeout = retryInterval
 }
 
 func logInfo(format string, values ...interface{}) {

--- a/core.go
+++ b/core.go
@@ -67,14 +67,15 @@ var (
 	keyValueUpdateRetryInterval      = time.Second * 5
 
 	// TBD: how much buffering should we allow?
-	eventQueueLength            = 128
-	bulkDataQueueLength         = 128
-	commandQueueLength          = 128
-	keyValueSyncQueueLength     = 128
-	keyValuePushQueueLength     = 128
-	keyValueCallbackQueueLength = 128
-	bulkDataRequestQueueLength  = 128
-	bulkDataResponseQueueLength = 128
+	eventQueueLength                     = 128
+	bulkDataQueueLength                  = 128
+	commandQueueLength                   = 128
+	keyValueSyncQueueLength              = 128
+	keyValuePushQueueLength              = 128
+	keyValueCallbackQueueLength          = 128
+	bulkDataRequestQueueLength           = 128
+	subscribeBulkDataResponseQueueLength = 128
+	bulkDataResponseQueueLength          = 128
 )
 
 // SetRESTHostPort overrides the default REST API server host and port, and specifies
@@ -204,6 +205,12 @@ type (
 		RequestID string                 `json:"requestId"`
 		Payload   map[string]interface{} `json:"payload"`
 		qos       QOSLevel               // not exported to serializer
+	}
+
+	// DeviceSubscribeBulkDataResponse is request of subscribing bulk data response topic.
+	DeviceSubscribeBulkDataResponse struct {
+		StreamID string
+		qos      QOSLevel
 	}
 
 	// DeviceBulkDataResponse is response struct of "request/response" for bulkData.

--- a/core.go
+++ b/core.go
@@ -73,6 +73,8 @@ var (
 	keyValueSyncQueueLength     = 128
 	keyValuePushQueueLength     = 128
 	keyValueCallbackQueueLength = 128
+	bulkDataRequestQueueLength  = 128
+	bulkDataResponseQueueLength = 128
 )
 
 // SetRESTHostPort overrides the default REST API server host and port, and specifies
@@ -195,6 +197,25 @@ type (
 	// A callback function that is invoked when a key-value pair has been deleted.
 	// The key of the deleted key-value is passed in the argument.
 	KeyValueDeletedCallback func(*DeviceContext, string)
+
+	// DeviceBulkDataRequest is request struct of "request/response" for bulkData.
+	DeviceBulkDataRequest struct {
+		StreamID  string                 `json:"-"`
+		RequestID string                 `json:"requestId"`
+		Payload   map[string]interface{} `json:"payload"`
+		qos       QOSLevel               // not exported to serializer
+	}
+
+	// DeviceBulkDataResponse is response struct of "request/response" for bulkData.
+	DeviceBulkDataResponse struct {
+		StreamID  string                 `json:"-"`
+		RequestID string                 `json:"requestId"`
+		Status    string                 `json:"status"`
+		Payload   map[string]interface{} `json:"payload,omitempty"`
+	}
+
+	// BulkDataResponseReceiver receive a response of a bulk data request from Stream.
+	BulkDataResponseReceiver func(*DeviceContext, *DeviceBulkDataResponse)
 )
 
 // ProvisionDevice is used for on-demand device provisioning. It takes a

--- a/mqtt.go
+++ b/mqtt.go
@@ -583,6 +583,8 @@ func (mc *mqttConn) sendSubscribeBulkDataResponse(sub *DeviceSubscribeBulkDataRe
 		},
 	}
 
+	mc.outPacket <- p
+
 	select {
 	case <-time.After(deviceEventRetryInterval):
 		msg := fmt.Sprintf("did not receive SUBACK of event delivery for packet ID %d", p.PacketID)
@@ -593,7 +595,7 @@ func (mc *mqttConn) sendSubscribeBulkDataResponse(sub *DeviceSubscribeBulkDataRe
 		if ack.PacketID == p.PacketID {
 			logInfo("[MQTT] received SUBACK for packet ID %d", ack.PacketID)
 
-			if len(ack.ReturnCodes) != 0 {
+			if len(ack.ReturnCodes) != 1 {
 				logError("[MQTT] received SUBACK packet with incorrect number of return codes: expect 1; got %d", len(ack.ReturnCodes))
 				return errors.New("invalid packet")
 			}

--- a/mqtt.go
+++ b/mqtt.go
@@ -411,7 +411,7 @@ func (mc *mqttConn) sendEvent(e *DeviceEvent) error {
 	logInfo("[MQTT] waiting for PUBACK for packet ID %d", p.PacketID)
 
 	select {
-	case <-time.After(deviceEventRetryInterval):
+	case <-time.After(deviceEventTimeout):
 		msg := fmt.Sprintf("did not receive PUBACK of event delivery for packet ID %d", p.PacketID)
 		logError("[MQTT] %s", msg)
 		mc.reportError(fmt.Errorf("event delivery timeout: %s", msg))
@@ -461,7 +461,7 @@ func (mc *mqttConn) sendBulkData(b *DeviceBulkData) error {
 	logInfo("[MQTT] waiting for PUBACK for packet ID %d", p.PacketID)
 
 	select {
-	case <-time.After(deviceEventRetryInterval):
+	case <-time.After(deviceEventTimeout):
 		msg := fmt.Sprintf("did not receive PUBACK of bulk data delivery for packet ID %d", p.PacketID)
 		logError("[MQTT] %s", msg)
 		mc.reportError(fmt.Errorf("bulk data delivery timeout: %s", msg))
@@ -496,7 +496,7 @@ func (mc *mqttConn) writeBulkData(b *DeviceSyncedBulkData) error {
 	logInfo("[MQTT] waiting for PUBACK for packet ID %d", p.PacketID)
 
 	select {
-	case <-time.After(syncedBulkDataRetryInterval):
+	case <-time.After(syncedBulkDataTimeout):
 		msg := fmt.Sprintf("did not receive PUBACK of synced bulk data delivery for packet ID %d", p.PacketID)
 		logError("[MQTT] %s", msg)
 		mc.reportError(fmt.Errorf("synced bulk data delivery timeout: %s", msg))
@@ -549,7 +549,7 @@ func (mc *mqttConn) sendBulkDataRequest(b *DeviceBulkDataRequest) error {
 	logInfo("[MQTT] waiting for PUBACK for packet ID %d", p.PacketID)
 
 	select {
-	case <-time.After(deviceEventRetryInterval):
+	case <-time.After(deviceEventTimeout):
 		msg := fmt.Sprintf("did not receive PUBACK of event delivery for packet ID %d", p.PacketID)
 		logError("[MQTT] %s", msg)
 		mc.reportError(fmt.Errorf("event delivery timeout: %s", msg))
@@ -586,7 +586,7 @@ func (mc *mqttConn) sendSubscribeBulkDataResponse(sub *DeviceSubscribeBulkDataRe
 	mc.outPacket <- p
 
 	select {
-	case <-time.After(deviceEventRetryInterval):
+	case <-time.After(deviceEventTimeout):
 		msg := fmt.Sprintf("did not receive SUBACK of event delivery for packet ID %d", p.PacketID)
 		logError("[MQTT] %s", msg)
 		mc.reportError(fmt.Errorf("event delivery timeout: %s", msg))

--- a/mqtt.go
+++ b/mqtt.go
@@ -407,7 +407,7 @@ func (mc *mqttConn) publishData(topic string, payloadObject interface{}, qos QOS
 
 	mc.outPacket <- p
 
-	logInfo("[MQTT] payload delivery to %s for packet ID %d", p.PacketID, topic)
+	logInfo("[MQTT] payload delivery to %s for packet ID %d", topic, p.PacketID)
 
 	if qos == QOSAtMostOnce {
 		return nil

--- a/mqtt.go
+++ b/mqtt.go
@@ -540,7 +540,7 @@ func (mc *mqttConn) sendBulkDataRequest(b *DeviceBulkDataRequest) error {
 
 	mc.outPacket <- p
 
-	logInfo("[MQTT] bulkData request delivery for packet ID %d", p.PacketID)
+	logInfo("[MQTT] bulkData request delivery for packet ID %d and requestID %s", p.PacketID, b.RequestID)
 
 	if b.qos == QOSAtMostOnce {
 		return nil

--- a/session.go
+++ b/session.go
@@ -240,7 +240,19 @@ func resubscribeBulkDataResponse() error {
 	logInfo("[Session] Start re-setting SubscribeBulkDataResponse")
 	defer logInfo("[Session] Finished re-setting SubscribeBulkDataResponse")
 
-	for streamID, receiver := range bulkDataResponseReceivers {
+	oldReceivers := bulkDataResponseReceivers
+	// Re-create map object
+	bulkDataResponseReceivers = map[string]BulkDataResponseReceiver{}
+	// Copy
+	for streamID, receiver := range oldReceivers {
+		bulkDataResponseReceivers[streamID] = receiver
+	}
+	// SetBulkDataResponseReceiver has side effect for bulkDataResponseReceivers map.
+	// So loop uses coped map object.
+	// And if MQTT happened error then it losts topic and receiver from map.
+	// So bulkDataResponseReceivers is created the new map object and it is copied map
+	// from old map at previous lines.
+	for streamID, receiver := range oldReceivers {
 		if err := SetBulkDataResponseReceiver(streamID, receiver); err != nil {
 			logError("[Session] Re subscriber failed to subsrive %s: %v", streamID, err)
 			return err


### PR DESCRIPTION
## Summary

This PR is for supporting Smart Module request/response as new feature of Smart Module.

request/response can send request to Data Stream and receive its response from it.
Request is sent by PUBLISH. And Response is received by SUBSCRIBE.

## Note

Currently v3 is designing. So maybe this implementation will to be transitional implementation. And this PR has problem. Mainly first use case is Stream Data Service (SDS). SDS send a lot of data. It will occupy a lot of bandwidth. But this PR implementation is using one TCP connection. So it is possible late of operation and sending event data. 

## Sample

The following code is sample of using this code.
https://github.com/moderepo/main/blob/mod_sds/cloud/smart_modules/mod_sds/dev/test_uploader/experimental/main.go
