### PR TITLE
Checkpoint

### DIFF
--- a/v3/mqtt_dummy.go
+++ b/v3/mqtt_dummy.go
@@ -3,6 +3,7 @@ package mode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,23 +13,36 @@ import (
 	packet "github.com/moderepo/device-sdk-go/v3/mqtt_packet"
 )
 
-// Not really for export, but
 type publishMode int
+type dummyCmd int
 
 const (
 	publishKvUpdate publishMode = iota
 	publishCommand
-	publishNone
+
+	// publishes a kv sync
+	publishKvCmd dummyCmd = iota
+	// publishes a command
+	publishCommandCmd
+	shutdownCmd
+	slowdownServerCmd
 )
 
 var (
-	testMqttHost               = "localhost"
-	testMqttPort               = 1998
-	useTLS                     = false
-	requestTimeout             = 2 * time.Second
-	_pubMode       publishMode = publishNone
-	currentDevice              = ""
+	testMqttHost   = "localhost"
+	testMqttPort   = 1998
+	useTLS         = false
+	requestTimeout = 2 * time.Second
+	currentDevice  = ""
 )
+
+type dummyContext struct {
+	ctx         context.Context
+	cmdCh       chan dummyCmd
+	listener    net.Listener
+	currentConn net.Conn
+	waitTime    time.Duration
+}
 
 func doConnect(connPkt *packet.ConnectPacket) (*packet.ConnackPacket, bool) {
 	ackPack := packet.NewConnackPacket()
@@ -61,66 +75,85 @@ func writePacket(conn net.Conn, pkt packet.Packet, bigPacket bool) error {
 	return nil
 }
 
-func readStream(conn net.Conn) bool {
-	keepConn := true
-	for keepConn {
-		tmp := make([]byte, 256)
-		n, err := conn.Read(tmp)
-		if err != nil {
-			if err != io.EOF {
-				logError("[MQTTD] Error reading packet from client: %s", err)
-			}
-			break
+func readPacket(conn net.Conn) (numBytes int, bytesRead []byte, err error) {
+	tmp := make([]byte, 256)
+	numBytes, err = conn.Read(tmp)
+	if err != nil {
+		if err == io.EOF {
+			// EOF means client closed the connection. We treat this as a
+			// normal operation.
+			return numBytes, tmp[0:1], nil
 		}
-		l, ty := packet.DetectPacket(tmp[0:n])
-		var pkt packet.Packet
-		if ty == packet.CONNECT {
-			inPkt := packet.NewConnectPacket()
-			inPkt.Decode(tmp[0:l])
-			pkt, keepConn = doConnect(inPkt)
-		} else if ty == packet.SUBSCRIBE {
-			pkt = &packet.SubackPacket{PacketID: 1, ReturnCodes: []byte{packet.QOSAtMostOnce, packet.QOSAtMostOnce}}
-		} else if ty == packet.PINGREQ {
-			pkt = packet.NewPingrespPacket()
-		} else if ty == packet.DISCONNECT {
-			// Let the caller close
-			return false
-		} else if ty == packet.PUBLISH {
-			inPkt := packet.NewPublishPacket()
-			inPkt.Decode(tmp[0:l])
-			// If it's QOS 1, create an ack packet.
-			if inPkt.Message.QOS == packet.QOSAtLeastOnce {
-				pubAck := packet.NewPubackPacket()
-				pubAck.PacketID = inPkt.PacketID
-				pkt = pubAck
-			} else {
-				continue
-			}
-		} else {
-			logInfo("[MQTTD] Unhandled data from client: %s (%s)", l, ty)
-			continue
-		}
-
-		if err := writePacket(conn, pkt, false); err != nil {
-			logError("[MQTTD] Error writing packet to client: %s", err)
-			break
-		}
+		logError("[MQTTD] Error reading packet from client: %s", err)
+		return 0, nil, err
 	}
-	return false
+	return numBytes, tmp, nil
 }
 
-func handleSession(conn net.Conn) {
-	// Read until
-	if readStream(conn) {
-		return
+func handleSession(context *dummyContext, conn net.Conn) {
+	keepConn := true
+
+	for keepConn {
+		// Read until command says quit or we get a disconnect
+		bytesRead, packetBytes, err := readPacket(conn)
+		if context.waitTime > 0 {
+			logInfo("Pausing server...")
+			timer := time.NewTimer(context.waitTime)
+			<-timer.C
+			logInfo("Continuing server...")
+		}
+
+		if err != nil {
+			logError("[MQTTD] Error reading packet from stream: %s", err)
+			keepConn = false
+		}
+		var respPkt packet.Packet
+		respPkt, keepConn = getResponsePacket(packetBytes, bytesRead)
+		if respPkt != nil {
+			if err := writePacket(conn, respPkt, false); err != nil {
+				logError("[MQTTD] Error writing packet to client: %s", err)
+				// write error is likely a missing client, so we end the connection
+				keepConn = false
+			}
+		}
 	}
 	conn.Close()
 }
 
-func handlePublish(conn net.Conn) {
+func getResponsePacket(pktBytes []byte, pktLen int) (pkt packet.Packet, keepConn bool) {
+	keepConn = true
+	l, ty := packet.DetectPacket(pktBytes[0:pktLen])
+	if ty == packet.CONNECT {
+		inPkt := packet.NewConnectPacket()
+		inPkt.Decode(pktBytes[0:l])
+		pkt, keepConn = doConnect(inPkt)
+	} else if ty == packet.SUBSCRIBE {
+		pkt = &packet.SubackPacket{PacketID: 1, ReturnCodes: []byte{packet.QOSAtMostOnce, packet.QOSAtMostOnce}}
+	} else if ty == packet.PINGREQ {
+		pkt = packet.NewPingrespPacket()
+	} else if ty == packet.DISCONNECT {
+		pkt = nil
+		keepConn = false
+	} else if ty == packet.PUBLISH {
+		inPkt := packet.NewPublishPacket()
+		inPkt.Decode(pktBytes[0:l])
+		// If it's QOS 1, create an ack packet.
+		if inPkt.Message.QOS == packet.QOSAtLeastOnce {
+			pubAck := packet.NewPubackPacket()
+			pubAck.PacketID = inPkt.PacketID
+			pkt = pubAck
+		} else {
+			pkt = nil
+		}
+	}
+
+	return pkt, keepConn
+}
+
+func sendPublish(conn net.Conn, pubMode publishMode) {
 	var pkt packet.Packet
 
-	switch _pubMode {
+	switch pubMode {
 	case publishKvUpdate:
 		kvData := KeyValueSync{
 			Action:   KVSyncActionReload,
@@ -158,12 +191,10 @@ func handlePublish(conn net.Conn) {
 		cmdPkt.Message = m
 		cmdPkt.PacketID = 2
 		pkt = cmdPkt
-	case publishNone:
-		// just return
 	}
 
 	if pkt != nil {
-		timer := time.NewTimer(2 * time.Second)
+		timer := time.NewTimer(1 * time.Second)
 		<-timer.C
 
 		if err := writePacket(conn, pkt, true); err != nil {
@@ -172,38 +203,86 @@ func handlePublish(conn net.Conn) {
 	}
 }
 
-func startAccepting(listener net.Listener) {
+func runServer(wg *sync.WaitGroup, context *dummyContext, listener net.Listener) {
+	defer wg.Done()
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			continue
+			break
 		}
-		go handleSession(conn)
-		go handlePublish(conn)
+		context.currentConn = conn
+		handleSession(context, conn)
 	}
 }
 
-func startServing(ctx context.Context, wg *sync.WaitGroup, readyCh chan struct{}) {
+func runCommandHandler(wg *sync.WaitGroup, context *dummyContext) {
+	defer wg.Done()
+	for cmd := range context.cmdCh {
+		switch cmd {
+		case publishKvCmd:
+			// Waits 2 seconds, then publishes, so don't wait
+			go sendPublish(context.currentConn, publishKvUpdate)
+		case publishCommandCmd:
+			// Waits 2 seconds, then publishes, so don't wait
+			go sendPublish(context.currentConn, publishCommand)
+		case slowdownServerCmd:
+			context.waitTime = 3 * time.Second
+		case shutdownCmd:
+			performShutdown(context)
+		}
+	}
+}
+
+func runWaitForCancel(wg *sync.WaitGroup, context *dummyContext) {
+	defer wg.Done()
+	<-context.ctx.Done()
+	performShutdown(context)
+}
+
+func performShutdown(context *dummyContext) {
+	// Tells the server to not accept new connections
+	context.listener.Close()
+	// Close the current connection
+	context.currentConn.Close()
+	if context.cmdCh != nil {
+		// close the command channel so it doesn't listen to any more commands
+		close(context.cmdCh)
+	}
+}
+
+// Dummy MQTT server. It will run an MQTT server as a goroutine. An optional
+// command channel can be passed in to manipulate the server manipulating test
+// conditions and shutting down.
+// Unlike the v2 dummyMQTTD, this starts goroutines but isn't meant to be run as
+// a goroutine. It will panic if it is unable to start listening.
+//
+// To end the server, either close the command channel or call cancel() on the
+// context.
+func dummyMQTTD(ctx context.Context, wg *sync.WaitGroup,
+	cmdCh chan dummyCmd) bool {
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", testMqttHost, testMqttPort))
 	if err != nil {
 		panic(err)
 	}
 
-	go startAccepting(l)
-	close(readyCh)
-	<-ctx.Done()
-	logInfo("[MQTTD] Shutting down server")
-	l.Close()
-	wg.Done()
-}
+	context := dummyContext{
+		ctx:      ctx,
+		cmdCh:    cmdCh,
+		listener: l,
+		waitTime: 0,
+	}
 
-// Dummy server, with a context that will shut us down
-// modeMode means run as a Mode MQTT Server, not a generic one
-func dummyMQTTD(ctx context.Context, wg *sync.WaitGroup, mode publishMode) {
-	_pubMode = mode
-	readyCh := make(chan struct{})
+	if cmdCh != nil && ctx != nil {
+		panic(errors.New("dummy server cannot run with context.Context *and* a command channel"))
+	}
+	if cmdCh != nil {
+		go runCommandHandler(wg, &context)
+	} else {
+		// No command channel, so wait for the context to shut us down
+		go runWaitForCancel(wg, &context)
+	}
+	wg.Add(1)
+	go runServer(wg, &context, l)
 
-	go startServing(ctx, wg, readyCh)
-	// Wait to return until we've started the server
-	<-readyCh
+	return true
 }

--- a/v3/mqtt_mode.go
+++ b/v3/mqtt_mode.go
@@ -3,6 +3,8 @@ package mode
 
 import (
 	"bytes"
+	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,7 +62,8 @@ type (
 		dc            *DeviceContext
 		subscriptions map[string]mqttMsgHandler
 
-		requestTimeout time.Duration
+		outgoingQueueSize uint16
+		responseTimeout   time.Duration
 
 		// For handling our subscriptions. Output
 		command chan<- *DeviceCommand
@@ -69,29 +72,58 @@ type (
 		// For receiving data from the API. Input (but we create and manage
 		// them)
 		SubRecvCh  chan MqttSubData
-		QueueAckCh chan MqttQueueResult
-		PingAckCh  chan bool
+		QueueAckCh chan MqttResponse
+		PingAckCh  chan MqttResponse
 	}
 )
 
+type (
+	ModeMqttOptDuration    time.Duration
+	ModeMqttOptQueueLength int16
+
+	ModeMqttDelegateOpt interface {
+		apply(d *ModeMqttDelegate)
+	}
+)
+
+func (dur ModeMqttOptDuration) apply(del *ModeMqttDelegate) {
+	del.responseTimeout = time.Duration(dur)
+}
+
+func (len ModeMqttOptQueueLength) apply(del *ModeMqttDelegate) {
+	del.outgoingQueueSize = uint16(len)
+}
+
 // Maybe have the channel sizes as parameters.
-func NewModeMqttDelegate(dc *DeviceContext, cmdQueue chan<- *DeviceCommand,
-	kvSyncQueue chan<- *KeyValueSync) *ModeMqttDelegate {
+func NewModeMqttDelegate(
+	dc *DeviceContext,
+	cmdQueue chan<- *DeviceCommand,
+	kvSyncQueue chan<- *KeyValueSync,
+	opts ...ModeMqttDelegateOpt) *ModeMqttDelegate {
 	del := &ModeMqttDelegate{
-		dc:             dc,
-		requestTimeout: 4 * time.Second,
-		command:        cmdQueue,
-		kvSync:         kvSyncQueue,
-		SubRecvCh:      make(chan MqttSubData),
-		QueueAckCh:     make(chan MqttQueueResult),
-		PingAckCh:      make(chan bool),
+		dc:                dc,
+		outgoingQueueSize: 8,               // some default
+		responseTimeout:   2 * time.Second, // some default
+		command:           cmdQueue,
+		kvSync:            kvSyncQueue,
+		SubRecvCh:         make(chan MqttSubData),
+		QueueAckCh:        make(chan MqttResponse),
+		PingAckCh:         make(chan MqttResponse),
 	}
 	subs := make(map[string]mqttMsgHandler)
 	subs[fmt.Sprintf("/devices/%d/command", dc.DeviceID)] = del.handleCommandMsg
 	subs[fmt.Sprintf("/devices/%d/kv", dc.DeviceID)] = del.handleKeyValueMsg
 
 	del.subscriptions = subs
+
+	for _, opt := range opts {
+		opt.apply(del)
+	}
 	return del
+}
+
+func (del ModeMqttDelegate) GetDeviceContext() *DeviceContext {
+	return del.dc
 }
 
 // Non-MqttDelegate method to listen on subscriptions and pass the interpreted
@@ -102,7 +134,7 @@ func (del ModeMqttDelegate) RunSubscriptionListener() {
 		select {
 		case subData := <-del.SubRecvCh:
 			subBytes := subData.data
-			// Determine which callback to call based on the
+			// Determine which callback to call based on the topic
 			if handler, exists := del.subscriptions[subData.topic]; exists {
 				if err := handler(subBytes); err != nil {
 					logError("Error in subscription handler: %s", err)
@@ -114,22 +146,28 @@ func (del ModeMqttDelegate) RunSubscriptionListener() {
 	}
 }
 
+func (del ModeMqttDelegate) TLSUsageAndConfiguration() (useTLS bool,
+	tlsConfig *tls.Config) {
+	// useTLS is a package level variable
+	return useTLS, del.dc.TLSConfig
+}
+
 func (del ModeMqttDelegate) AuthInfo() (username string, password string) {
 	// format as decimal
 	return strconv.FormatUint(del.dc.DeviceID, 10), del.dc.AuthToken
 }
 
-func (del ModeMqttDelegate) ReceiveChannels() (subRecvCh chan<- MqttSubData,
-	pubAckCh chan<- MqttQueueResult,
-	pingAckCh chan<- bool) {
+func (del ModeMqttDelegate) GetChannels() (subRecvCh chan<- MqttSubData,
+	pubAckCh chan MqttResponse,
+	pingAckCh chan MqttResponse) {
 	return del.SubRecvCh, del.QueueAckCh, del.PingAckCh
 }
 
-func (del ModeMqttDelegate) RequestTimeout() time.Duration {
-	return del.requestTimeout
+func (del ModeMqttDelegate) OutgoingQueueSize() uint16 {
+	return del.outgoingQueueSize
 }
 
-func (del ModeMqttDelegate) Subscriptions() []string {
+func (del ModeMqttDelegate) GetSubscriptions() []string {
 	keys := make([]string, len(del.subscriptions))
 
 	i := 0
@@ -140,9 +178,13 @@ func (del ModeMqttDelegate) Subscriptions() []string {
 	return keys
 }
 
-func (del ModeMqttDelegate) Close() {
+func (del ModeMqttDelegate) OnClose() {
 	close(del.command)
 	close(del.kvSync)
+}
+
+func (del ModeMqttDelegate) createContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), del.responseTimeout)
 }
 
 func (del ModeMqttDelegate) handleCommandMsg(data []byte) error {
@@ -183,7 +225,7 @@ func (del ModeMqttDelegate) handleKeyValueMsg(data []byte) error {
 
 // Mode extensions to the MqttClient
 // cast to the concrete delegate
-func (client *MqttClient) getModeDelegate() (*ModeMqttDelegate, error) {
+func (client *MqttClient) GetModeDelegate() (*ModeMqttDelegate, error) {
 	implDelegate, ok := client.delegate.(*ModeMqttDelegate)
 	if !ok {
 		return implDelegate, fmt.Errorf("MqttClient was not created with Mode Delegate")
@@ -194,7 +236,7 @@ func (client *MqttClient) getModeDelegate() (*ModeMqttDelegate, error) {
 
 // Helper function to send DeviceEvent instances
 func (client *MqttClient) PublishEvent(event DeviceEvent) (uint16, error) {
-	modeDel, err := client.getModeDelegate()
+	modeDel, err := client.GetModeDelegate()
 	if err != nil {
 		return 0, err
 	}
@@ -204,16 +246,17 @@ func (client *MqttClient) PublishEvent(event DeviceEvent) (uint16, error) {
 		return 0, err
 	}
 	topic := fmt.Sprintf("/devices/%d/event", modeDel.dc.DeviceID)
-
-	return client.Publish(event.Qos, topic, payload)
+	ctx, cancel := modeDel.createContext()
+	defer cancel()
+	return client.Publish(ctx, event.Qos, topic, payload)
 }
 
 // Helper function to send DeviceEvent instances. This replaces both the
 // sendBulkData and writeBulkData methods in the old API (since it does less
-// than both, covering just the intersection of the other
+// than both, covering just the intersection)
 func (client *MqttClient) PublishBulkData(bulkData DeviceBulkData) (uint16,
 	error) {
-	modeDel, err := client.getModeDelegate()
+	modeDel, err := client.GetModeDelegate()
 	if err != nil {
 		return 0, err
 	}
@@ -221,7 +264,9 @@ func (client *MqttClient) PublishBulkData(bulkData DeviceBulkData) (uint16,
 	topic := fmt.Sprintf("/devices/%d/bulkData/%s", modeDel.dc.DeviceID,
 		bulkData.StreamID)
 
-	return client.Publish(bulkData.Qos, topic, bulkData.Blob)
+	ctx, cancel := modeDel.createContext()
+	defer cancel()
+	return client.Publish(ctx, bulkData.Qos, topic, bulkData.Blob)
 }
 
 // The key value store should typically be cached. Key Values are all sent on
@@ -231,7 +276,7 @@ func (client *MqttClient) PublishBulkData(bulkData DeviceBulkData) (uint16,
 // XXX: Looks like there's a reload, so I must be missing something.
 func (client *MqttClient) PublishKeyValueUpdate(kvData KeyValueSync) (uint16,
 	error) {
-	modeDel, err := client.getModeDelegate()
+	modeDel, err := client.GetModeDelegate()
 	if err != nil {
 		return 0, err
 	}
@@ -243,7 +288,9 @@ func (client *MqttClient) PublishKeyValueUpdate(kvData KeyValueSync) (uint16,
 	topic := fmt.Sprintf("/devices/%d/kv", modeDel.dc.DeviceID)
 
 	// Hardcode QOS1
-	return client.Publish(QOSAtLeastOnce, topic, payload)
+	ctx, cancel := modeDel.createContext()
+	defer cancel()
+	return client.Publish(ctx, QOSAtLeastOnce, topic, payload)
 }
 
 // A special JSON decoder that makes sure numbers in command parameters

--- a/v3/mqtt_mode_test.go
+++ b/v3/mqtt_mode_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -40,25 +42,22 @@ func newModeMqttDelegate() (*ModeMqttDelegate, chan *DeviceCommand,
 }
 
 // Helper for some tests
-func testModeConnection(t *testing.T, delegate MqttDelegate,
-	expectError bool) *MqttClient {
-	client := NewMqttClient(modeMqttHost, modeMqttPort, nil, modeUseTLS,
-		delegate)
-	err := client.Connect()
+func testModeConnection(ctx context.Context, t *testing.T,
+	delegate *ModeMqttDelegate, expectError bool) *MqttClient {
+	client := NewMqttClient(modeMqttHost, modeMqttPort, delegate)
+	ctx, cancel := delegate.createContext()
+	defer cancel()
+	err := client.Connect(ctx)
 	if expectError {
-		if err == nil {
-			t.Errorf("Did not receive expected error")
-		}
-	} else if err != nil {
-		t.Errorf("Connect failed: %s", err)
+		assert.NotNil(t, err, "Did not receive expected error")
+	} else {
+		assert.Nil(t, err, "Connect failed")
 	}
 	isConnected := client.IsConnected()
 	if expectError {
-		if isConnected {
-			t.Errorf("IsConnected should not be true")
-		}
-	} else if !isConnected {
-		t.Errorf("IsConnected is false after connection")
+		assert.False(t, isConnected, "IsConnected should not be true")
+	} else {
+		assert.True(t, isConnected, "IsConnected is false after connection")
 	}
 
 	return client
@@ -68,18 +67,14 @@ func testModeConnection(t *testing.T, delegate MqttDelegate,
 func testModeWaitForPubAck(t *testing.T, delegate *ModeMqttDelegate,
 	expectTimeout bool) uint16 {
 	// Wait for the ack, or timeout
-	ctx, cancel := context.WithTimeout(context.Background(),
-		delegate.RequestTimeout())
+	ctx, cancel := delegate.createContext()
 	defer cancel()
 
 	// Block on the return channel or timeout
 	select {
-	case queueRes := <-delegate.QueueAckCh:
-		if queueRes.Err != nil {
-			t.Errorf("Queued request failed: %s", queueRes.Err)
-		} else {
-			return queueRes.PacketId
-		}
+	case queueResp := <-delegate.QueueAckCh:
+		assert.Nil(t, queueResp.Err, "Queued request failed")
+		return queueResp.PacketID
 	case <-ctx.Done():
 		if !expectTimeout {
 			t.Errorf("Ack response timeout: %s", ctx.Err())
@@ -95,19 +90,20 @@ func TestModeMqttClientConnection(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestModeMqttClientConnection: test bad user/pass")
 	badDelegate, _, _ := invalidModeMqttDelegate()
-	testModeConnection(t, badDelegate, true)
+	testModeConnection(ctx, t, badDelegate, true)
 
 	fmt.Println("TestModeMqttClientConnection: test good user/pass")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
+	// force the cancel before the wait
 	cancel()
 	wg.Wait()
 }
@@ -116,16 +112,16 @@ func TestModeMqttClientSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestModeMqttClientSubscribe")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
-	if err := client.Subscribe(); err != nil {
-		t.Errorf("failed to subscribe: %s", err)
+	client := testModeConnection(ctx, t, goodDelegate, false)
+	if errs := client.Subscribe(ctx); errs != nil {
+		t.Errorf("failed to subscribe: %s", errs)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -134,42 +130,37 @@ func TestModeMqttClientSubscribe(t *testing.T) {
 
 func TestModeMqttClientPing(t *testing.T) {
 	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPing")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
 
-	if err := client.Ping(); err != nil {
+	if err := client.Ping(ctx); err != nil {
 		t.Errorf("Ping send failed: %s", err)
 	}
 
-	// Wait for the ack, or timeout
-	ctx, cancel := context.WithTimeout(context.Background(),
-		client.delegate.RequestTimeout())
-	defer cancel()
-
 	// Block on the return channel or timeout
 	select {
-	case ret := <-goodDelegate.PingAckCh:
+	case resp := <-goodDelegate.PingAckCh:
 		// There's not really a way to return false, but, since it's bool, we'll
 		// check
-		if !ret {
-			t.Errorf("Ping response was false")
+		if resp.Err != nil {
+			t.Errorf("Ping response returned error: %s", resp.Err)
 		}
 	case <-ctx.Done():
 		t.Errorf("Ping response timeout: %s", ctx.Err())
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
-	serverCancel()
+	cancel()
 	wg.Wait()
 }
 
@@ -177,11 +168,11 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishEvent")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
@@ -192,13 +183,13 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 		Qos:       QOSAtMostOnce,
 	}
 
-	fmt.Println("Testing timeout for QOS 0")
 	var packetId uint16
 	packetId, err := client.PublishEvent(event)
 	if err != nil {
 		t.Errorf("Publish failed: %s", err)
 	}
 
+	fmt.Println("QOS 0. No ACK, so make sure we don't get one")
 	returnId := testModeWaitForPubAck(t, goodDelegate, true)
 	if returnId != 0 {
 		t.Errorf("Received an Ack for QOS 0")
@@ -217,7 +208,7 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 			packetId, returnId)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -226,15 +217,15 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 
 // Only test QOS 1 for this (QOS 0 was tested in PublishEvent, so, unless we
 // hit a bug with BulkData publishing, I think that's sufficient.
-func TestModeMqttClientPublishBulkData(t *testing.T) {
+func aTestModeMqttClientPublishBulkData(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishBulkData")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
@@ -242,16 +233,15 @@ func TestModeMqttClientPublishBulkData(t *testing.T) {
 	bulk := DeviceBulkData{
 		StreamID: "stream1",
 		Blob:     []byte("blob"),
-		Qos:      QOSAtLeastOnce,
+		Qos:      QOSAtMostOnce,
 	}
 	_, err := client.PublishBulkData(bulk)
-	if err != nil {
-		t.Errorf("PublishDeviceBulkData send failed: %s", err)
-	}
+	assert.Nil(t, err, "PublishDeviceBulkData send failed")
 
+	logInfo("[MQTT Test] disconnecting")
 	// From looking at the original session.go, I believe this was QOS0 (no
 	// ACK. So, once we send it, we're done
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -262,11 +252,11 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishKVUpdate")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
@@ -318,7 +308,7 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 			packetId, returnId)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -327,18 +317,21 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 
 // When we first connect and subscribe to the kv topic, we'll get a sync.
 // This is a good test to see that we're receiving.
-func TestModeMqttClientReceiveKvSync(t *testing.T) {
+func TestModeMqttClientReceiveKVSync(t *testing.T) {
 	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
+	cmdCh := make(chan dummyCmd)
 	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishKvUpdate)
+	dummyMQTTD(nil, &wg, cmdCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	fmt.Println("TestModeMqttClientReceiveKvSync")
 	goodDelegate, _, kvSyncChannel := newModeMqttDelegate()
-	client := NewMqttClient(modeMqttHost, modeMqttPort, nil, modeUseTLS,
-		goodDelegate)
-	client.Connect()
-
+	client := NewMqttClient(modeMqttHost, modeMqttPort, goodDelegate)
+	client.Connect(ctx)
+	// Tell the server to send a kv update
+	cmdCh <- publishKvCmd
 	// Start the listener
 	go goodDelegate.RunSubscriptionListener()
 
@@ -346,15 +339,13 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 		t.Errorf("Failed to connect")
 	}
 
-	if err := client.Subscribe(); err != nil {
+	if err := client.Subscribe(ctx); err != nil {
 		t.Errorf("failed to subscribe: %s", err)
 	}
 
-	// 3 seconds seems to be the correct timing for this test to cause the bulk
-	// sync to be sent by the server
-	d := time.Now().Add(3 * time.Second)
-	ctx, cancel := context.WithDeadline(context.Background(), d)
-	defer cancel()
+	d := time.Now().Add(2 * time.Second)
+	syncCtx, syncCancel := context.WithDeadline(context.Background(), d)
+	defer syncCancel()
 
 	receivedSubData := false
 	select {
@@ -363,7 +354,7 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 		fmt.Printf("Data: %v\n", kvSync)
 		receivedSubData = true
 		break
-	case <-ctx.Done():
+	case <-syncCtx.Done():
 		t.Errorf("Timed out waiting for command")
 	}
 
@@ -371,10 +362,10 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 		t.Errorf("Did not receive KV Sync")
 	}
 	fmt.Println("Exiting")
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
-	serverCancel()
+	cmdCh <- shutdownCmd
 	wg.Wait()
 }
 
@@ -382,16 +373,18 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 // initiate this automatically
 func TestModeMqttClientReceiveCommand(t *testing.T) {
 	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
+	cmdCh := make(chan dummyCmd)
 	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishCommand)
+	dummyMQTTD(nil, &wg, cmdCh)
 
 	fmt.Println("TestModeMqttClientReceiveCommand")
 	goodDelegate, cmdChannel, _ := newModeMqttDelegate()
-	client := NewMqttClient(modeMqttHost, modeMqttPort, nil, modeUseTLS,
-		goodDelegate)
-	client.Connect()
+	client := NewMqttClient(modeMqttHost, modeMqttPort, goodDelegate)
+	ctx, cancel := goodDelegate.createContext()
+	defer cancel()
+	client.Connect(ctx)
 
+	cmdCh <- publishCommandCmd
 	// Start the listener
 	go goodDelegate.RunSubscriptionListener()
 
@@ -399,15 +392,9 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 		t.Errorf("Failed to connect")
 	}
 
-	if err := client.Subscribe(); err != nil {
+	if err := client.Subscribe(ctx); err != nil {
 		t.Errorf("failed to subscribe: %s", err)
 	}
-
-	// 3 seconds seems to be the correct timing for this test to cause the bulk
-	// sync to be sent by the server
-	d := time.Now().Add(10 * time.Second)
-	ctx, cancel := context.WithDeadline(context.Background(), d)
-	defer cancel()
 
 	receivedSubData := false
 	select {
@@ -423,9 +410,9 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 		t.Errorf("Did not receive command")
 	}
 	fmt.Println("Exiting")
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
-	serverCancel()
+	cmdCh <- shutdownCmd
 	wg.Wait()
 }


### PR DESCRIPTION
Major refactoring

Note:
This PR is for merging into v3_baseline, which was already reviewed. If you reviewed the code before, it might be helpful to see the diff from that version. But, maybe it's better just to look at it as brand new code.

After the first code block, Lawrence had suggestions for simplifying the code. I hope the code is simpler now.
 - Removed a mutex lock. Both the synchronous and asynchronous now send through a channel into one goroutine to send packets. So, no chance of more than one goroutine writing to the stream
 - No more creating a channel for each subscription. Originally, subscriptions were asynchronous, and creating channels for each subscribe was left from that. Removed it
 - Removed some API from the delegate. After testing out write timeouts, I think it's better just to use a context.Context in the API. The user can wrap it if they so desire.

For testing:
 - Reorganized the dummy MQTT server to take commands while it's running and modified the tests to match. Fixed an intermittent bug with Disconnect (don't defer in a defer)
 - Started using stretchr/testify. This was being used in the other test, so the dependency on this module already exists. We should switch entirely, but this PR is already huge.