### PR TITLE
Major refactoring

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -1,6 +1,7 @@
-// MQTT Client the Mode MQTT API
-// The interface is through the MQTTClient struct, which supports the MQTT
-// subset that is required for our devices.
+// Package Mode implements the Mode Client MQTT API
+// The interface is through the MqttClient struct, which supports the MQTT
+// subset that is required for our devices and configuration is through the
+// MqttDelegate.
 package mode
 
 import (
@@ -34,27 +35,56 @@ const (
 	// QoS 1 - message is delivered at least once, but duplicates may happen.
 	QOSAtLeastOnce
 
-	// QoS 2 - message is always delivered exactly once. This is currently not supported.
+	// QoS 2 - message is always delivered exactly once. This is currently not
+	// supported.
 	QOSExactlyOnce
 )
 
+type packetSendType int
+
+const (
+	// Packets are written out to the stream immediately (or after the
+	// the previous packet has finished sending)
+	directPacketSendType packetSendType = iota
+	// Packets are queued and written when processed
+	queuedPacketSendType
+	unhandledPacketSendType
+)
+
+type NetworkStatus int
+
+const (
+	// There is currently an active connection to the server
+	ConnectedNetworkStatus NetworkStatus = iota
+	// We have successfully disconnected to the server
+	DisconnectedNetworkStatus
+	// If we have had requests time out, we set to timing out. We should
+	// reconnect.
+	TimingOutNetworkStatus
+	// Not yet connected state
+	DefaultNetworkStatus
+)
+
 type (
-	// Data to send in the channel to the client when we receive data
-	// published for our subscription
+	// MqttSubData to send in the channel to the client when we receive data
+	// published for our subscription.
 	MqttSubData struct {
 		topic string
 		data  []byte
 	}
 
-	// Data to send in the channel to the client when we receive the
-	// PUBACK on publish, or an error
-	MqttQueueResult struct {
-		PacketId uint16
+	// MqttResponse is result of an MQTT Request. Not all of these members will
+	// be valid. For example, only PUBACK's will have PacketIds, and PUBLISH'es
+	// will send subscription data. In some cases, there will be multiple
+	// errors, so the Errs slice will be populated rather than the Errs.
+	MqttResponse struct {
+		PacketID uint16
 		Err      error
+		Errs     []error
 	}
 
-	// For users of MqttClient. Three responsibilities (Oops. single
-	// responsibility, blah blah.):
+	// MqttDelegate should be implemented by users of MqttClient. Three
+	// responsibilities (Oops. single responsibility, blah blah.):
 	// - data needed to establish a connection
 	// - Callback method to create data to publish
 	// - channels to communicate data back to a receiver.
@@ -63,120 +93,147 @@ type (
 	// another interface (and the struct implement the interface if desired).
 	// But this is sufficient for now.
 	MqttDelegate interface {
+		// Returns the tls usage and configuration. If useTLS is false, a nil
+		// tlsConfig should be returned.
+		TLSUsageAndConfiguration() (useTLS bool, tlsConfig *tls.Config)
 		// Returns authentication information
 		AuthInfo() (username string, password string)
-		// Returns the 3 channels on which we will receive information:
-		// spubRecvCh: Data published from our subscriptions
-		// pubAckCh: We will receive MqttPublishID's, which will correspond
-		//   to the return value of Publish()
-		// pingAckCh: True if our ping received an ACK or false if timeout
-		// The delegate is responsible for creating these channels to be of
-		// sufficient size. This is the only mechanism for communicating with
-		// the user. If necessary, the user can create a queue to ensure
-		// that no data is lost.
-		ReceiveChannels() (subRecvCh chan<- MqttSubData,
-			queueAckCh chan<- MqttQueueResult,
-			pingAckCh chan<- bool)
 
-		// How long to wait for requests to finish
-		RequestTimeout() time.Duration
+		// SetReceiveChannels will be called by the MqttClient. The MqttClient
+		// will create the channels with the buffer size returned by
+		// GetReceieveQueueSize(). The implementor of the delegate will use
+		// these channels to receive information from the server, such as
+		// queued responses and subscriptions:
+		// subRecvCh: Data published from our subscriptions.
+		// queueAckCh: API requests that are queued will receive MqttPublishID's
+		// which will be ACK'ed. The MqttQueueResult will have the
+		// MqttPublishID and the result
+		// pingAckCh: True if our ping received an ACK or false if timeout
+		SetReceiveChannels(subRecvCh <-chan MqttSubData,
+			queueAckCh <-chan MqttResponse,
+			pingAckCh <-chan MqttResponse)
+
+		// Buffer size of the incoming queues to the delegate. This is the
+		// size of the three receive channels
+		GetReceiveQueueSize() uint16
+
+		// Buffer size of the outgoing queue to the server. This cannot be
+		// changed after a connection is created
+		GetSendQueueSize() uint16
 
 		// Retrieve the topics for this delegate
-		Subscriptions() []string
+		GetSubscriptions() []string
 
 		// Hook so we can clean up on closing of connections
-		Close()
+		OnClose()
 	}
 
+	// MqttClient provides the public API to MQTT. We handle
+	// connect, disconnect, ping, publish, and subscribe.
+	// Connect, disconnect, and subscribe will block and wait for the
+	// response. Ping and publish will return after the packet has been
+	// sent and the response will be sent on a channel that is provided
+	// by the delegate. For ping, since MQTT does not provide a mechanism
+	// to distinguish between different ping requests, we do not provide
+	// an API to distinguish them either. For publish, the function returns
+	// a packet ID. This packet ID will be returned to the caller in the
+	// channel.
 	MqttClient struct {
-		// Provides the public API to MQTT. We handle
-		// connect, disconnect, ping (internal)
-		// publish, and subscribe. All functions are synchronous.
+		mqttHost  string
+		mqttPort  int
+		delegate  MqttDelegate
+		conn      *mqttConn
+		wgSend    sync.WaitGroup // wait on sending
+		wgRecv    sync.WaitGroup // wait on receiving
+		lastError error
 
-		isConnected bool
-		delegate    MqttDelegate
-		conn        *mqttConn
-		wgSend      sync.WaitGroup // wait on sending
-		wgRecv      sync.WaitGroup // wait on receiving
+		delegateSubRecvCh chan MqttSubData
 	}
 
 	// Delegate for the mqqtConn to call back to the MqttClient
-	mqttPubReceiver interface {
+	mqttReceiver interface {
+		// Called by the connection when receiving publishes
 		handlePubReceive(*packet.PublishPacket)
+		// Called by the connection when there is an error
+		setError(error)
+	}
+
+	packetSendData struct {
+		pkt      packet.Packet
+		resultCh chan<- MqttResponse
 	}
 
 	// Type alias for something that we use everywhere
-	mqttPacketChan chan packet.Packet
+	mqttSendPacketChan chan packetSendData
+
 	// Internal structure used by the client to communicate with the mqttd
 	// server. This is a thin wrapper over the mqtt_packet package.
 	mqttConn struct {
-		// delegate to handle receiving publishes. Of course, achannel would
-		// be an alternate way to do this, but this delegate is currently
-		// just doing some verification and getting the bytes out of the
-		// packet and putting it into a channel, so adding another channel
-		// for that would add unneeded overhead. If circumstances change,
-		// change, we can revisit this decision.
-		PubHandler mqttPubReceiver
+		// delegate to handle receiving asynchronous events from the server.
+		// This is more explicit than a channel, but it has the drawback
+		// of just being a functional call. So, the implementation should
+		// consist of routing (which it is, since it is just a callback
+		// into the MqttClient). If circumstances change, change, we can
+		// revisit this decision.
+		Receiver mqttReceiver
 
 		conn   net.Conn
 		stream *packet.Stream
-		// Sequential packet ID. Used to match acks our actions (pub, sub)
+		// Sequential packet ID. Used to match to acks our actions (pub)
 		// excluding connects and pings. We also don't have packet ID's for
 		// receiving pubs from our subscriptions because we didn't initiate them.
 		lastPacketID uint16
 
-		// Channels to respond to clients
-		packIDToChan map[uint16]mqttPacketChan
-		outPktCh     mqttPacketChan
-		connRespCh   mqttPacketChan
-		pingRespCh   chan<- bool
-		queueAckCh   chan<- MqttQueueResult
+		status NetworkStatus
+
+		// Updated on every send and receive so we know if we can avoid
+		// sending pings
+		lastActivity time.Time
+
+		// Channel to write to the server stream
+		directSendPktCh chan packetSendData
+		queuedSendPktCh chan packetSendData
+		// Channels to respond to clients.
+		connRespCh chan MqttResponse
+		subRespCh  chan MqttResponse
+		pingRespCh chan MqttResponse
+		queueAckCh chan MqttResponse
 
 		mutex sync.Mutex
 	}
-
-	MqttClientError error
 )
 
-// Creates a client and connects. A client is invalid if not connected, and
-// you need to create a new client to reconnect and subscribe
-// a pingInterval of zero means no keepalive pings
-func NewMqttClient(mqttHost string, mqttPort int, tlsConfig *tls.Config,
-	useTLS bool, delegate MqttDelegate) *MqttClient {
-	_, queueAckCh, pingAchCh := delegate.ReceiveChannels()
-	conn := newMqttConn(tlsConfig, mqttHost, mqttPort, useTLS, queueAckCh,
-		pingAchCh)
-	if conn == nil {
-		return nil
+// NewMqttClient will create client and open a stream. A client is invalid if
+// not connected, and you need to create a new client to reconnect.
+func NewMqttClient(mqttHost string, mqttPort int,
+	delegate MqttDelegate) *MqttClient {
+	return &MqttClient{
+		mqttHost: mqttHost,
+		mqttPort: mqttPort,
+		delegate: delegate,
 	}
 
-	client := &MqttClient{
-		isConnected: false,
-		delegate:    delegate,
-		conn:        conn,
-	}
-	conn.PubHandler = client
-
-	// We want to pass our WaitGroup's to the connection reader and writer, so
-	// we don't put these in the mqttConn's constructor.
-	client.wgSend.Add(1)
-	go conn.runPacketWriter(&client.wgSend)
-	client.wgRecv.Add(1)
-	go conn.runPacketReader(&client.wgRecv)
-
-	// Connect and Subscribe here. These are exposed for now, but we might
-	// want to move them to non-public
-	return client
 }
 
-// Const function, but we don't want to pass client by value
+// IsConnected will return true if we have a successfully CONNACK'ed response.
+//
 func (client *MqttClient) IsConnected() bool {
-	return client.isConnected
+	return client.conn.status == ConnectedNetworkStatus
 }
 
-// exported for now, but pretty sure this needs to be called only from
-// NewMqttclient. This blocks until we get a Connection Ack
-func (client *MqttClient) Connect() error {
+// GetLastActivity will return the time since the last send or
+// receive.
+func (client *MqttClient) GetLastActivity() time.Time {
+	return client.conn.lastActivity
+}
+
+// Connect will initiate a connection to the server. It will block until we
+// receive a CONNACK from the server.
+func (client *MqttClient) Connect(ctx context.Context) error {
+	if client.conn != nil {
+		return errors.New("Cannot connect when already connect")
+	}
+	client.createMqttConnection()
 	user, pwd := client.delegate.AuthInfo()
 	p := packet.NewConnectPacket()
 	p.Version = packet.Version311
@@ -184,64 +241,56 @@ func (client *MqttClient) Connect() error {
 	p.Password = pwd
 	p.CleanSession = true
 
-	respChan, err := client.conn.SendPacket(p)
+	respChan, err := client.conn.sendPacket(ctx, p)
 	if err != nil {
 		logError("[MQTT] failed to send packet: %s", err.Error())
 		return err
 	}
 
-	var pkt packet.Packet
 	client.wgRecv.Add(1)
-	if pkt, err = client.receivePacket(respChan); err != nil {
-		logError("[MQTT] failed to receive packet %s", err)
-		return err
+	resp := client.receivePacket(ctx, respChan)
+	if resp.Err != nil {
+		client.conn.status = DisconnectedNetworkStatus
+		return resp.Err
 	}
-
-	if pkt.Type() != packet.CONNACK {
-		logError("[MQTT] received unexpected packet %s", pkt.Type())
-		return errors.New("unexpected response")
-	}
-
-	ack := pkt.(*packet.ConnackPacket)
-	if ack.ReturnCode != packet.ConnectionAccepted {
-		return fmt.Errorf("connection failed: %s", ack.ReturnCode.Error())
-	}
-
 	// If we made it here, we consider ourselves connected
-	client.isConnected = true
+	client.conn.status = ConnectedNetworkStatus
 
 	return nil
 }
 
-// This blocks until we receive an ACK (really, an EOF) from the server and
-// all our connections are done
-func (client *MqttClient) Disconnect() error {
+// Disconnect will end this connection with the server. We will block until
+// the server closes the connection.
+// Note: We might want to wait, but order is important here.
+func (client *MqttClient) Disconnect(ctx context.Context) error {
 	defer func() {
-		client.delegate.Close()
-		client.wgSend.Wait() // wait for packet sender to finish
-
-		// Disconnects don't send a packet. Just make sure we wait for the EOF
-		defer client.wgRecv.Wait()
+		client.shutdownConnection()
+		close(client.delegateSubRecvCh)
+		client.delegate.OnClose()
 	}()
 
-	// Creates a new context, using the client's timeout
+	// Maybe we want to add a Connecting/Disconnecting status?
+	client.conn.status = DefaultNetworkStatus
 	p := packet.NewDisconnectPacket()
-	_, err := client.conn.SendPacket(p)
+	_, err := client.conn.sendPacket(ctx, p)
 	if err != nil {
 		logError("[MQTT] failed to send packet: %s", err.Error())
 		return err
 	}
-	client.conn.Close()
 
 	return nil
 }
 
-// Add the subscriptions from the delegate
-func (client *MqttClient) Subscribe() error {
+// Subscribe will query the delegate for its subscriptions via the
+// GetSubscriptions method. This is a synchronous call so it will block until
+// a response is received from the server. It will return a slice of errors
+// which will be in the same order as the subscriptions in GetSubscriptions().
+func (client *MqttClient) Subscribe(ctx context.Context) []error {
 	p := packet.NewSubscribePacket()
 	p.Subscriptions = make([]packet.Subscription, 0, 10)
+	p.PacketID = client.conn.getPacketID()
 
-	subs := client.delegate.Subscriptions()
+	subs := client.delegate.GetSubscriptions()
 	for _, sub := range subs {
 		// We have no protection to keep you from subscribing to the same
 		// topic multiple times. Maybe we should? Maybe the server would send
@@ -254,49 +303,29 @@ func (client *MqttClient) Subscribe() error {
 		})
 	}
 
-	respChan, err := client.conn.SendPacket(p)
+	respChan, err := client.conn.sendPacket(ctx, p)
 	if err != nil {
 		logError("[MQTT] failed to send packet: %s", err.Error())
-		return err
+		return []error{err}
 	}
 
-	var pkt packet.Packet
 	client.wgRecv.Add(1)
-	if pkt, err = client.receivePacket(respChan); err != nil {
-		return err
-	}
-
-	if pkt.Type() != packet.SUBACK {
-		logError("[MQTT] received unexpected packet %s", pkt.Type())
-		return errors.New("unexpected response")
-	}
-
-	ack := pkt.(*packet.SubackPacket)
-	if len(ack.ReturnCodes) != len(subs) {
-		logError("[MQTT] received SUBACK packet with incorrect number of return codes: expect %d; got %d", len(subs), len(ack.ReturnCodes))
-		return errors.New("invalid packet")
-	}
-
-	for i, code := range ack.ReturnCodes {
-		sub := subs[i]
-
-		if code == packet.QOSFailure {
-			logError("[MQTT] subscription to topic %s rejected", sub)
-			return errors.New("subscription rejected")
-		}
-
-		logInfo("[MQTT] subscription to topic %s succeeded with QOS %v",
-			sub, code)
+	resp := client.receivePacket(ctx, respChan)
+	if resp.Errs != nil {
+		return resp.Errs
 	}
 
 	return nil
 }
 
-func (client *MqttClient) Ping() error {
+// Ping sends an MQTT PINGREQ event to the server. This is an asynchronous
+// call, so we will always return success if we were able to queue the message
+// for delivery. Any subsequent results will be sent on the delegate's
+// pingAckCh.
+func (client *MqttClient) Ping(ctx context.Context) error {
 
 	p := packet.NewPingreqPacket()
-
-	_, err := client.conn.QueuePacket(p, client.delegate.RequestTimeout())
+	_, err := client.conn.queuePacket(ctx, p)
 	if err != nil {
 		logError("[MQTT] failed to send packet: %s", err.Error())
 		return err
@@ -305,8 +334,18 @@ func (client *MqttClient) Ping() error {
 	return nil
 }
 
-func (client *MqttClient) Publish(qos QOSLevel, topic string,
-	data []byte) (uint16, error) {
+// Publish sends an MQTT Publish event to subscribers on the specified
+// topic. This is an asynchronous call, so we will always return a packet
+// ID as long as the request is able to be queued. After queueing, the
+// any subsequent errors or results will be written to the delegate's
+// queueAckCh.
+// For QOSAtMostOnce, there will only be an error returned if the request was
+// unable to be queued. We receive no ACK from the server.
+// For QOSAtLeastOnce, we will receive an ACK if we were successful.
+// For any other QOS levels (QOSExactlyOnce), they are not supported and an
+// error is returned immediately and the request will not be sent.
+func (client *MqttClient) Publish(ctx context.Context, qos QOSLevel,
+	topic string, data []byte) (uint16, error) {
 
 	var pktQos byte
 	switch qos {
@@ -325,55 +364,107 @@ func (client *MqttClient) Publish(qos QOSLevel, topic string,
 		QOS:     pktQos,
 		Payload: data,
 	}
-	logInfo("Publishing on topic [%s]", p.Message.Topic)
+	logInfo("[MQTT] Publishing on topic [%s]", p.Message.Topic)
 
-	return client.conn.QueuePacket(p, client.delegate.RequestTimeout())
+	return client.conn.queuePacket(ctx, p)
 }
 
-func (client *MqttClient) receivePacket(respChan mqttPacketChan) (packet.Packet,
-	error) {
-	defer client.wgRecv.Done()
+// Each connect, we need to create a new mqttConnection.
+func (client *MqttClient) createMqttConnection() {
+	receiveQueueSize := client.delegate.GetReceiveQueueSize()
+	subRecvCh := make(chan MqttSubData, receiveQueueSize)
+	queueAckCh := make(chan MqttResponse, receiveQueueSize)
+	pingAckCh := make(chan MqttResponse, receiveQueueSize)
+	client.delegate.SetReceiveChannels(subRecvCh, queueAckCh, pingAckCh)
+	client.delegateSubRecvCh = subRecvCh
+	useTLS, tlsConfig := client.delegate.TLSUsageAndConfiguration()
+	sendQueueSize := client.delegate.GetSendQueueSize()
+	// XXX - we pass quit a few arguments to the connection. Maybe we should
+	// pass in the delegate instead. This allows the delegate to provide the
+	// connection to give data to dynamically
+	conn := newMqttConn(tlsConfig, client.mqttHost, client.mqttPort, useTLS,
+		queueAckCh, pingAckCh, sendQueueSize)
 
-	ctx, cancel := context.WithTimeout(context.Background(),
-		client.delegate.RequestTimeout())
-	defer cancel()
+	client.conn = conn
+	conn.Receiver = client
+
+	// We want to pass our WaitGroup's to the connection reader and writer, so
+	// we don't put these in the mqttConn's constructor.
+	client.wgSend.Add(1)
+	go conn.runPacketWriter(&client.wgSend)
+	client.wgRecv.Add(1)
+	go conn.runPacketReader(&client.wgRecv)
+}
+
+// Shutting down gracefully is tricky. But, we try our best to drain the channels
+// and avoid any panics.
+func (client *MqttClient) shutdownConnection() {
+	// We skip encapsulation of the connection class so the steps are clear
+	// 1. Close the channels to stop writing. This will break the
+	//    packetWriter goroutine out of its loop
+	close(client.conn.directSendPktCh)
+	close(client.conn.queuedSendPktCh)
+	// 2. wait for packet sender to finish
+	client.wgSend.Wait()
+	// 3. Close the connection with the server. This will break the
+	//    packet reader out of its loop. Set to disconnected here so their
+	//    reader knows that it was not an error
+	client.conn.status = DisconnectedNetworkStatus
+	client.conn.conn.Close()
+	// 4. Wait for the packet reader to finish
+	client.wgRecv.Wait()
+	// 5. Close the channels for handling responses
+	close(client.conn.connRespCh)
+	close(client.conn.subRespCh)
+	close(client.conn.queueAckCh)
+	close(client.conn.pingRespCh)
+	client.conn = nil
+}
+
+// Helper function called by the synchronous API to handle processing
+// of the responses. For the asynchronous API, the caller might do something
+// similar, but also handling packet ID's.
+func (client *MqttClient) receivePacket(ctx context.Context,
+	respChan chan MqttResponse) MqttResponse {
+	defer func() {
+		client.wgRecv.Done()
+	}()
 
 	// Block on the return channel or timeout
 	select {
-	case pkt := <-respChan:
-		// If this happens, we were blocked on a channel waiting for a packet
-		// and the server closed the connection
-		if pkt == nil {
-			return pkt, errors.New("connection closed")
-		} else {
-			return pkt, nil
-		}
+	case response := <-respChan:
+		return response
 	case <-ctx.Done():
 		err := ctx.Err()
+		//debug.PrintStack()
 		logError("[MQTT] timeout waiting for reply packet %s", err)
-		return nil, err
+		return MqttResponse{Err: err}
 	}
 }
 
-// Implementation of the delegate for mqttConn to handle publish from the server
-// on topics that we've subscribed to. We only unpack it and send it to the
-// caller
+// Implementation of the delegate for mqttConn to handle publish from the
+// server on topics that we've subscribed to. We only unpack it and send it
+// to the caller
 func (client *MqttClient) handlePubReceive(p *packet.PublishPacket) {
 	logInfo("[MQTT] received message for topic %s", p.Message.Topic)
 
 	pubData := MqttSubData{p.Message.Topic, p.Message.Payload}
 
-	subRecvCh, _, _ := client.delegate.ReceiveChannels()
 	select {
-	case subRecvCh <- pubData:
+	case client.delegateSubRecvCh <- pubData:
 	default:
-		logError("Caller could not receive publish data. Channel full?")
+		logError("Caller could not receive publish data. SubRecCh full?")
+		client.lastError = errors.New("SubRecCh channel is full")
 	}
 }
 
+func (client *MqttClient) setError(err error) {
+	client.lastError = err
+}
+
 func newMqttConn(tlsConfig *tls.Config, mqttHost string,
-	mqttPort int, useTLS bool, queueAckCh chan<- MqttQueueResult,
-	pingAckCh chan<- bool) *mqttConn {
+	mqttPort int, useTLS bool, queueAckCh chan MqttResponse,
+	pingAckCh chan MqttResponse, outgoingQueueSize uint16) *mqttConn {
 
 	addr := fmt.Sprintf("%s:%d", mqttHost, mqttPort)
 	var conn net.Conn
@@ -396,51 +487,55 @@ func newMqttConn(tlsConfig *tls.Config, mqttHost string,
 	return &mqttConn{
 		conn:   conn,
 		stream: packet.NewStream(conn, conn),
-		// This map will grow to the size of the number of requests that are
-		// unanswered. These block, so a size of 1 is sufficient.
-		packIDToChan: make(map[uint16]mqttPacketChan, 1),
-		// Channel to the mqtt server. This can possibly get backed up on a slow
-		// network. The size of 8 is arbitrary. If it is full, we will block
-		// until a timeout (specified by the delegate) and return an error.
-		outPktCh: make(mqttPacketChan, 8),
-		// Connection requests are blocked, so 1 is sufficient
-		connRespCh: make(mqttPacketChan, 1),
-		// These are created by the delegate, so it's up to them to create
-		// channels of sufficient size or we will fail.
+		status: DefaultNetworkStatus,
+
+		// The two channels that we write packets to send. The packetWriter
+		// will listen on these and write out to the stream.
+		// blocking, non-buffered
+		directSendPktCh: make(chan packetSendData),
+		// blocking, queue size specified by the delegate. If it is insufficient,
+		// we will lose packets.
+		queuedSendPktCh: make(chan packetSendData, outgoingQueueSize),
+
+		// Connection requests are blocking, so no buffer
+		connRespCh: make(chan MqttResponse),
+		subRespCh:  make(chan MqttResponse),
+
+		// These are passed to us by the client, with a buffer sized specified
+		// by the delegate, so it is the delegate's responsibility to set the
+		// size appropriately or we will start losing responses.
 		pingRespCh: pingAckCh,
 		queueAckCh: queueAckCh,
 	}
 }
 
-func (conn *mqttConn) Close() {
-	conn.closeAllChannels()
-}
-
 // We only queue pings (PINGREQ) and publishes (PUBLISH). Theoretically, we
 // could queue subscribes (SUBSCRIBE) since they have packet ID's like
-// publishes. But, to be able to handle queueing and sending for the same type
-// of packet would make the code overly complicated.
-func (conn *mqttConn) QueuePacket(p packet.Packet,
-	timeout time.Duration) (uint16, error) {
-
-	var packetID uint16
-	switch p.Type() {
-	case packet.PINGREQ:
-		// We send these as is, without adding a packet ID
-	case packet.PUBLISH:
-		pubPkt := p.(*packet.PublishPacket)
-		packetID = conn.getPacketID()
-		pubPkt.PacketID = uint16(packetID)
-	default:
-		logError("[MQTT] Unhandled packet type: %s", p.Type())
-		return 0, fmt.Errorf("Unhandled packet type for queueing")
+// publishes. But, for simplicity, those are synchronous, since, in practice,
+// those are either on startup, or, at least, on rare occasions.
+func (conn *mqttConn) queuePacket(ctx context.Context,
+	p packet.Packet) (uint16, error) {
+	if conn.status == DisconnectedNetworkStatus ||
+		conn.status == TimingOutNetworkStatus {
+		return 0, errors.New("Connection unstable. Unable to send")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	packetID := uint16(0)
+	if p.Type() == packet.PUBLISH {
+		packetID = conn.getPacketID()
+		pubPkt := p.(*packet.PublishPacket)
+		pubPkt.PacketID = uint16(packetID)
+	}
+
+	pktSendData := packetSendData{pkt: p,
+		resultCh: conn.getResponseChannel(p.Type()),
+	}
+
 	select {
-	case conn.outPktCh <- p:
-		// Successfully sent, so nothing to do.
+	// Put writing to the channel in a select because the buffer might be full
+	case conn.queuedSendPktCh <- pktSendData:
+		// Successfully sent and we don't know when we'll get a response back,
+		// so just don't do anything.
 	case <-ctx.Done():
 		logError("Exceeded timeout sending %s for id %d", p.Type(), packetID)
 		return 0, fmt.Errorf("Send Queue full %s for id %d", p.Type(), packetID)
@@ -449,14 +544,31 @@ func (conn *mqttConn) QueuePacket(p packet.Packet,
 	return packetID, nil
 }
 
-// Called by the client to send packets to the server.
-func (conn *mqttConn) SendPacket(p packet.Packet) (mqttPacketChan, error) {
+// Called by the client to send packets to the server
+func (conn *mqttConn) sendPacket(ctx context.Context,
+	p packet.Packet) (chan MqttResponse, error) {
+	if conn.status == DisconnectedNetworkStatus ||
+		conn.status == TimingOutNetworkStatus {
+		return nil, errors.New("Connection unstable. Unable to send")
+	}
 
-	ch := conn.getResponseChan(p)
+	resultCh := make(chan MqttResponse)
+	defer close(resultCh)
 
-	err := conn.writePacket(p)
+	select {
+	case conn.directSendPktCh <- packetSendData{
+		pkt:      p,
+		resultCh: resultCh,
+	}:
+	case <-ctx.Done():
+		logError("Exceeded timeout sending %s", p.Type())
+		return nil, errors.New("Timeout Error")
+	}
 
-	return ch, err
+	// Wait for the result, and then give that result back to the caller, who
+	// will handle the error
+	result := <-resultCh
+	return conn.getResponseChannel(p.Type()), result.Err
 }
 
 func (conn *mqttConn) runPacketWriter(wg *sync.WaitGroup) {
@@ -465,27 +577,102 @@ func (conn *mqttConn) runPacketWriter(wg *sync.WaitGroup) {
 		wg.Done()
 	}()
 
-	// Run until closed
-	for p := range conn.outPktCh {
-		err := conn.writePacket(p)
-		if err != nil {
-			logError("Unable to write out packet %s", p.Type())
-			switch p.Type() {
-			case packet.PINGREQ:
-				conn.pingRespCh <- false
-			case packet.SUBSCRIBE:
-				subPkt := p.(*packet.SubscribePacket)
-				conn.queueAckCh <- MqttQueueResult{subPkt.PacketID, err}
-			case packet.PUBLISH:
-				pubPkt := p.(*packet.PublishPacket)
-				conn.queueAckCh <- MqttQueueResult{pubPkt.PacketID, err}
-			default:
-				// We don't have a packet ID (or did not expect to receive this
-				// packet type and fail in sending it
-				err := fmt.Errorf("Failed to queue packet %s", p.Type())
-				conn.queueAckCh <- MqttQueueResult{0, err}
+	shouldLoop := true
+	for shouldLoop {
+		// We read two channels for writing out packets. The directSend
+		// channel received synchronous, which has an unbuffered queue.
+		// The queuedSend can back up because the client already has an ID to
+		// check for the response.
+		// NOTE: Writes are sent on a bufio.Writer, so writes are almost
+		// guaranteed to succeed, even if they never reach the server. See the
+		// note in writePacket for more information.
+		select {
+		case pktSendData := <-conn.directSendPktCh:
+			resultCh := pktSendData.resultCh
+			// Verify that we have the write packet type for direct sends
+			if pktSendData.pkt == nil {
+				// Case where the channel is closed
+				shouldLoop = false
+				break
+			}
+			if conn.verifyPacketType(pktSendData.pkt.Type()) != directPacketSendType {
+				resultCh <- MqttResponse{
+					Err: errors.New("Packet type must be queued"),
+				}
+			} else {
+				resultCh <- MqttResponse{Err: conn.writePacket(pktSendData.pkt)}
+			}
+		case pktSendData := <-conn.queuedSendPktCh:
+			if pktSendData.pkt == nil {
+				// Case where the channel is closed
+				shouldLoop = false
+				break
+			}
+			pktID := uint16(0)
+			if pktSendData.pkt.Type() == packet.PUBLISH {
+				pubPkt := pktSendData.pkt.(*packet.PublishPacket)
+				pktID = pubPkt.PacketID
+			}
+			// Get the packet ID, if any, for errors
+			resultCh := pktSendData.resultCh
+			if conn.verifyPacketType(pktSendData.pkt.Type()) != queuedPacketSendType {
+				resultCh <- MqttResponse{
+					Err: errors.New("Packet type must be sent directly"),
+				}
+			} else {
+				err := conn.writePacket(pktSendData.pkt)
+				if err != nil {
+					// If there was an error sending, we can notify the caller
+					// immediately.
+					resultCh <- MqttResponse{
+						PacketID: pktID,
+						Err:      err,
+					}
+				}
 			}
 		}
+	}
+}
+
+// Returns the channel to send the response, and the response data. If this
+// gets complicated, we can handle each type separately
+func (conn *mqttConn) createResponseForPacket(p packet.Packet) MqttResponse {
+	switch p.Type() {
+	case packet.PINGRESP:
+		// successful ping response is just nil errors
+		return MqttResponse{Err: nil}
+	case packet.PUBACK:
+		pubAck := p.(*packet.PubackPacket)
+		return MqttResponse{PacketID: pubAck.PacketID, Err: nil}
+	case packet.CONNACK:
+		connAck := p.(*packet.ConnackPacket)
+		var err error = nil
+		if connAck.ReturnCode != packet.ConnectionAccepted {
+			err = connAck.ReturnCode
+		}
+		return MqttResponse{Err: err}
+	case packet.SUBACK:
+		subAck := p.(*packet.SubackPacket)
+		resp := MqttResponse{
+			// We have do asynchronous SUBSCRIPTIONS, so our packets won't
+			// have packet ID's. But, if we ever do them, this is one place that
+			// we won't have to change our code.
+			PacketID: subAck.PacketID,
+		}
+		for i, code := range subAck.ReturnCodes {
+			if code == packet.QOSFailure {
+				err := errors.New("subscription rejected")
+				if i == 0 {
+					// If someone just checks Err of the response, at least
+					// they'll know that there was a failur
+					resp.Errs = append(resp.Errs, err)
+				}
+			}
+		}
+		return resp
+	default:
+		logError("Unhandled packet type for response: ", p.Type())
+		return MqttResponse{}
 	}
 }
 
@@ -493,63 +680,68 @@ func (conn *mqttConn) runPacketReader(wg *sync.WaitGroup) {
 	defer func() {
 		logInfo("[MQTT] packet reader is exiting")
 		wg.Done()
-		// Close the rest of our channels?
 	}()
 
 	for {
+		// Set a deadline for reads to prevent blocking forever. We'll handle
+		// this error and continue looping, if appropriate
+		conn.conn.SetReadDeadline(time.Now().Add(time.Millisecond * 500))
 		p, err := conn.stream.Read()
+		conn.lastActivity = time.Now()
 		if err != nil {
-			if err == io.EOF {
+			// Disconnect "responses" are EOF
+			if err == io.EOF || conn.status == DisconnectedNetworkStatus {
 				// Server disconnected. This happens for 2 reasons:
-				// 1. we disconnect
-				// 2. we don't ping, so the server assumes we're done
-				// XXX we should wait for the EOF before we exit.
-				// In any case, we have to see if upstream this wasn't
-				// expected
-				// it wasn't expected upstream
-				logInfo("[MQTT] server disconnected: %s", err.Error())
+				// 1. We initiated a disconnect
+				// 2. we don't ping, so the server assumed we're done
+				logInfo("[MQTT] net.Conn disconnected: %s", err.Error())
 			} else {
+				// I/O Errors usually return this, so if it is, we can
+				// figure out what to do next
+				opError := err.(*net.OpError)
+				if opError != nil {
+					if os.IsTimeout(opError.Err) {
+						// 	// No problem - read deadline just exceeded
+						continue
+					}
+				}
 				logError("[MQTT] failed to read packet: %s", err.Error())
-				//conn.reportError(err)
 			}
+			// The signal to the caller that disconnect was complete is the
+			// exiting of this function (and wg.Done())
 			break
 		}
 		if p.Type() == packet.PUBLISH {
-			// Incoming, received from our subscription. (all outher packets
-			// are outbound.
+			// Incoming publish, received from our subscription.
 			pubPkt := p.(*packet.PublishPacket)
-			conn.PubHandler.handlePubReceive(pubPkt)
+			conn.Receiver.handlePubReceive(pubPkt)
 		} else {
-			respChan := conn.getResponseChan(p)
-			if respChan != nil {
-				respChan <- p
-				if p.Type() == packet.SUBACK {
-					subAck := p.(*packet.SubackPacket)
-					delete(conn.packIDToChan, subAck.PacketID)
-					close(respChan)
-				}
-			} else {
-				// Figure out what the packet was. If it's nil, it should
-				// be a response to a queued delivery
-				if p.Type() == packet.PINGRESP {
-					conn.pingRespCh <- true
-				} else if p.Type() == packet.PUBACK {
-					pubAck := p.(*packet.PubackPacket)
-					conn.queueAckCh <- MqttQueueResult{pubAck.PacketID, nil}
-				} else if p.Type() == packet.SUBACK {
-					subAck := p.(*packet.SubackPacket)
-					conn.queueAckCh <- MqttQueueResult{subAck.PacketID, nil}
-				}
+			// Everything besides publish and disconnect, so unpackage the
+			// packet data and send it to the appropriate channel
+			respData := conn.createResponseForPacket(p)
+			respCh := conn.getResponseChannel(p.Type())
+			logInfo("[MQTT] Received %s", p.Type())
+			select {
+			case respCh <- respData:
+				logInfo("[MQTT] Sent %s", p.Type())
+			default:
+				logError("[MQTT] Response channel is full. Dropping return packets")
+				conn.Receiver.setError(errors.New("Response channel full. Dropping packet"))
 			}
 		}
 	}
 }
 
 func (conn *mqttConn) writePacket(p packet.Packet) error {
-	// Since we have both queued writes, and blocking, we lock at the
-	// lowest level
-	conn.mutex.Lock()
-	defer conn.mutex.Unlock()
+	conn.lastActivity = time.Now()
+	// XXX - I've used a SetWriteDeadline() for this, even on Flush, but I've
+	// never gotten the write's to timeout. I think it's because the underlying
+	// stream is buffered. It still doesn't quite make sense, because Flush() on
+	// the buffered stream still forces a Write on the unbuffered Writer. My
+	// guess is that it's the nature of TCP. If there's no failure, even the
+	// lack of an ACK on write won't result in timing out. But, in any case, we
+	// will still have a response timeout on the round trip, which might be
+	// sufficient.
 	if err := conn.stream.Write(p); err != nil {
 		logError("[MQTT] failed to send %s packet: %s", p.Type(), err.Error())
 		return err
@@ -563,61 +755,49 @@ func (conn *mqttConn) writePacket(p packet.Packet) error {
 	return nil
 }
 
-func (conn *mqttConn) closeAllChannels() {
-
-	for _, v := range conn.packIDToChan {
-		close(v)
-	}
-
-	close(conn.outPktCh)
-	close(conn.connRespCh)
-	close(conn.pingRespCh)
-}
-
 func (conn *mqttConn) getPacketID() uint16 {
 	conn.mutex.Lock()
 	defer conn.mutex.Unlock()
-	conn.lastPacketID += 1
+	// If we were strictly incrementing, we could use atomic.AddUint32(), but
+	// we're also wrapping around, so we still need the mutex.
+	conn.lastPacketID++
 	if conn.lastPacketID == 0 {
 		conn.lastPacketID = 1
 	}
 	return conn.lastPacketID
 }
 
-// Returns the appropriate response channel for the channel type. For pubacks,
-// We will either create it or return the one that we stored previous
-func (conn *mqttConn) getResponseChan(p packet.Packet) mqttPacketChan {
-	//logInfo("[MQTT] Fetching response channel for %s\n", p.Type())
-	switch p.Type() {
-	case packet.CONNECT:
-		return conn.connRespCh
-	case packet.DISCONNECT:
-		// Disconnect is a special case. Server will close, so no response, but
-		// it's a packet type we expect, so don't let it fall to default
-		return nil
-	case packet.CONNACK:
-		return conn.connRespCh
-	case packet.SUBSCRIBE:
-		// Subscribes are blocking, but have packet ID's, and, theoretically,
-		// multiples can be sent, so we enable this at this level.
-		subPkt := p.(*packet.SubscribePacket)
-		subPkt.PacketID = conn.getPacketID()
-		returnCh := make(mqttPacketChan)
-		conn.packIDToChan[subPkt.PacketID] = returnCh
-		return returnCh
-	case packet.SUBACK:
-		// It's possible the SUBACK doesn't have a response channel if it
-		// was queued. In that case, we'll return a nil and handle it like
-		// PINGREQ or PUBACK
-		subAck := p.(*packet.SubackPacket)
-		return conn.packIDToChan[subAck.PacketID]
-	case packet.PUBLISH, packet.PINGREQ, packet.PUBACK, packet.PINGRESP:
-		// Since we have to respond differently to these, but we don't
-		// want to show an error
-		return nil
+// Sanity check to verify that we are queue'ing or non-queue'ing the correct
+// types of packets. ACK's are not queued, of course, but since we can use this
+// function to make route returns, we handle ACK's in this function too.
+func (conn *mqttConn) verifyPacketType(pktType packet.Type) packetSendType {
+	switch pktType {
+	case packet.CONNECT, packet.CONNACK, packet.DISCONNECT, packet.SUBSCRIBE,
+		packet.SUBACK:
+		return directPacketSendType
+	case packet.PUBLISH, packet.PUBACK, packet.PINGREQ, packet.PINGRESP:
+		return queuedPacketSendType
 	default:
 		//
-		logError("[MQTT] Unhandled packet type: %s", p.Type())
+		logError("[MQTT] Unhandled packet type: %s", pktType)
+		return unhandledPacketSendType
+	}
+}
+
+func (conn *mqttConn) getResponseChannel(pktType packet.Type) chan MqttResponse {
+	switch pktType {
+	case packet.CONNECT, packet.CONNACK:
+		return conn.connRespCh
+	case packet.SUBSCRIBE, packet.SUBACK:
+		return conn.subRespCh
+	case packet.PUBLISH, packet.PUBACK:
+		return conn.queueAckCh
+	case packet.PINGREQ, packet.PINGRESP:
+		return conn.pingRespCh
+	case packet.DISCONNECT:
+		return nil
+	default:
+		logError("[MQTT] Unhandled packet type: %s", pktType)
 		return nil
 	}
 }

--- a/v3/mqtt_dummy.go
+++ b/v3/mqtt_dummy.go
@@ -26,6 +26,7 @@ const (
 	publishCommandCmd
 	shutdownCmd
 	slowdownServerCmd
+	resetServerCmd
 )
 
 var (
@@ -233,6 +234,8 @@ func runCommandHandler(wg *sync.WaitGroup, context *dummyContext) {
 			}
 		case slowdownServerCmd:
 			context.waitTime = 3 * time.Second
+		case resetServerCmd:
+			context.waitTime = 0
 		case shutdownCmd:
 			performShutdown(context)
 		}

--- a/v3/mqtt_dummy.go
+++ b/v3/mqtt_dummy.go
@@ -127,7 +127,6 @@ func handleSession(context *dummyContext, conn net.Conn) {
 func getResponsePacket(pktBytes []byte, pktLen int) (pkt packet.Packet, keepConn bool) {
 	keepConn = true
 	l, ty := packet.DetectPacket(pktBytes[0:pktLen])
-	logInfo("[MQTTD] Server Received %d", ty)
 	if ty == packet.CONNECT {
 		inPkt := packet.NewConnectPacket()
 		inPkt.Decode(pktBytes[0:l])

--- a/v3/mqtt_dummy.go
+++ b/v3/mqtt_dummy.go
@@ -3,6 +3,7 @@ package mode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -12,23 +13,36 @@ import (
 	packet "github.com/moderepo/device-sdk-go/v3/mqtt_packet"
 )
 
-// Not really for export, but
 type publishMode int
+type dummyCmd int
 
 const (
 	publishKvUpdate publishMode = iota
 	publishCommand
-	publishNone
+
+	// publishes a kv sync
+	publishKvCmd dummyCmd = iota
+	// publishes a command
+	publishCommandCmd
+	shutdownCmd
+	slowdownServerCmd
 )
 
 var (
-	testMqttHost               = "localhost"
-	testMqttPort               = 1998
-	useTLS                     = false
-	requestTimeout             = 2 * time.Second
-	_pubMode       publishMode = publishNone
-	currentDevice              = ""
+	testMqttHost   = "localhost"
+	testMqttPort   = 1998
+	useTLS         = false
+	requestTimeout = 2 * time.Second
+	currentDevice  = ""
 )
+
+type dummyContext struct {
+	ctx      context.Context
+	cmdCh    chan dummyCmd
+	listener net.Listener
+	conns    []net.Conn
+	waitTime time.Duration
+}
 
 func doConnect(connPkt *packet.ConnectPacket) (*packet.ConnackPacket, bool) {
 	ackPack := packet.NewConnackPacket()
@@ -61,66 +75,89 @@ func writePacket(conn net.Conn, pkt packet.Packet, bigPacket bool) error {
 	return nil
 }
 
-func readStream(conn net.Conn) bool {
-	keepConn := true
-	for keepConn {
-		tmp := make([]byte, 256)
-		n, err := conn.Read(tmp)
-		if err != nil {
-			if err != io.EOF {
-				logError("[MQTTD] Error reading packet from client: %s", err)
-			}
-			break
+func readPacket(conn net.Conn) (numBytes int, bytesRead []byte, err error) {
+	tmp := make([]byte, 256)
+	numBytes, err = conn.Read(tmp)
+	if err != nil {
+		if err == io.EOF {
+			// EOF means client closed the connection. We treat this as a
+			// normal operation.
+			return numBytes, tmp[0:1], nil
 		}
-		l, ty := packet.DetectPacket(tmp[0:n])
-		var pkt packet.Packet
-		if ty == packet.CONNECT {
-			inPkt := packet.NewConnectPacket()
-			inPkt.Decode(tmp[0:l])
-			pkt, keepConn = doConnect(inPkt)
-		} else if ty == packet.SUBSCRIBE {
-			pkt = &packet.SubackPacket{PacketID: 1, ReturnCodes: []byte{packet.QOSAtMostOnce, packet.QOSAtMostOnce}}
-		} else if ty == packet.PINGREQ {
-			pkt = packet.NewPingrespPacket()
-		} else if ty == packet.DISCONNECT {
-			// Let the caller close
-			return false
-		} else if ty == packet.PUBLISH {
-			inPkt := packet.NewPublishPacket()
-			inPkt.Decode(tmp[0:l])
-			// If it's QOS 1, create an ack packet.
-			if inPkt.Message.QOS == packet.QOSAtLeastOnce {
-				pubAck := packet.NewPubackPacket()
-				pubAck.PacketID = inPkt.PacketID
-				pkt = pubAck
-			} else {
-				continue
-			}
-		} else {
-			logInfo("[MQTTD] Unhandled data from client: %s (%s)", l, ty)
-			continue
-		}
-
-		if err := writePacket(conn, pkt, false); err != nil {
-			logError("[MQTTD] Error writing packet to client: %s", err)
-			break
-		}
+		logError("[MQTTD] Error reading packet from client: %s", err)
+		return 0, nil, err
 	}
-	return false
+	return numBytes, tmp, nil
 }
 
-func handleSession(conn net.Conn) {
-	// Read until
-	if readStream(conn) {
-		return
+func handleSession(context *dummyContext, conn net.Conn) {
+	keepConn := true
+
+	for keepConn {
+		// Read until command says quit or we get a disconnect
+		bytesRead, packetBytes, err := readPacket(conn)
+		if context.waitTime > 0 {
+			logInfo("[MQTTD] Pausing server...")
+			timer := time.NewTimer(context.waitTime)
+			<-timer.C
+			logInfo("[MQTTD] Unpausing server...")
+		}
+
+		if err != nil {
+			logError("[MQTTD] Error reading packet from stream: %s", err)
+			keepConn = false
+			// we can't continue without a packet from the client
+			break
+		}
+		var respPkt packet.Packet
+		respPkt, keepConn = getResponsePacket(packetBytes, bytesRead)
+		if respPkt != nil {
+			if err := writePacket(conn, respPkt, false); err != nil {
+				logError("[MQTTD] Error writing packet to client: %s", err)
+				// write error is likely a missing client, so we end the connection
+				keepConn = false
+			}
+		}
 	}
+	logInfo("[MQTTD] closing connection")
 	conn.Close()
 }
 
-func handlePublish(conn net.Conn) {
+func getResponsePacket(pktBytes []byte, pktLen int) (pkt packet.Packet, keepConn bool) {
+	keepConn = true
+	l, ty := packet.DetectPacket(pktBytes[0:pktLen])
+	logInfo("[MQTTD] Server Received %d", ty)
+	if ty == packet.CONNECT {
+		inPkt := packet.NewConnectPacket()
+		inPkt.Decode(pktBytes[0:l])
+		pkt, keepConn = doConnect(inPkt)
+	} else if ty == packet.SUBSCRIBE {
+		pkt = &packet.SubackPacket{PacketID: 1, ReturnCodes: []byte{packet.QOSAtMostOnce, packet.QOSAtMostOnce}}
+	} else if ty == packet.PINGREQ {
+		pkt = packet.NewPingrespPacket()
+	} else if ty == packet.DISCONNECT {
+		pkt = nil
+		keepConn = false
+	} else if ty == packet.PUBLISH {
+		inPkt := packet.NewPublishPacket()
+		inPkt.Decode(pktBytes[0:l])
+		// If it's QOS 1, create an ack packet.
+		if inPkt.Message.QOS == packet.QOSAtLeastOnce {
+			pubAck := packet.NewPubackPacket()
+			pubAck.PacketID = inPkt.PacketID
+			pkt = pubAck
+		} else {
+			pkt = nil
+		}
+	}
+
+	return pkt, keepConn
+}
+
+func sendPublish(conn net.Conn, pubMode publishMode) {
 	var pkt packet.Packet
 
-	switch _pubMode {
+	switch pubMode {
 	case publishKvUpdate:
 		kvData := KeyValueSync{
 			Action:   KVSyncActionReload,
@@ -158,12 +195,10 @@ func handlePublish(conn net.Conn) {
 		cmdPkt.Message = m
 		cmdPkt.PacketID = 2
 		pkt = cmdPkt
-	case publishNone:
-		// just return
 	}
 
 	if pkt != nil {
-		timer := time.NewTimer(2 * time.Second)
+		timer := time.NewTimer(1 * time.Second)
 		<-timer.C
 
 		if err := writePacket(conn, pkt, true); err != nil {
@@ -172,38 +207,90 @@ func handlePublish(conn net.Conn) {
 	}
 }
 
-func startAccepting(listener net.Listener) {
+func runServer(wg *sync.WaitGroup, context *dummyContext, listener net.Listener) {
+	defer wg.Done()
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			continue
+			break
 		}
-		go handleSession(conn)
-		go handlePublish(conn)
+		context.conns = append(context.conns, conn)
+		go handleSession(context, conn)
 	}
 }
 
-func startServing(ctx context.Context, wg *sync.WaitGroup, readyCh chan struct{}) {
+func runCommandHandler(wg *sync.WaitGroup, context *dummyContext) {
+	defer wg.Done()
+	for cmd := range context.cmdCh {
+		switch cmd {
+		case publishKvCmd:
+			for _, conn := range context.conns {
+				go sendPublish(conn, publishKvUpdate)
+			}
+		case publishCommandCmd:
+			for _, conn := range context.conns {
+				go sendPublish(conn, publishCommand)
+			}
+		case slowdownServerCmd:
+			context.waitTime = 3 * time.Second
+		case shutdownCmd:
+			performShutdown(context)
+		}
+	}
+}
+
+func runWaitForCancel(wg *sync.WaitGroup, context *dummyContext) {
+	defer wg.Done()
+	<-context.ctx.Done()
+	performShutdown(context)
+}
+
+func performShutdown(context *dummyContext) {
+	// Tells the server to not accept new connections
+	context.listener.Close()
+	// Close the current connection
+	for _, conn := range context.conns {
+		conn.Close()
+	}
+	if context.cmdCh != nil {
+		// close the command channel so it doesn't listen to any more commands
+		close(context.cmdCh)
+	}
+}
+
+// Dummy MQTT server. It will run an MQTT server as a goroutine. An optional
+// command channel can be passed in to manipulate the server manipulating test
+// conditions and shutting down.
+// Unlike the v2 dummyMQTTD, this starts goroutines but isn't meant to be run as
+// a goroutine. It will panic if it is unable to start listening.
+//
+// To end the server, either close the command channel or call cancel() on the
+// context.
+func dummyMQTTD(ctx context.Context, wg *sync.WaitGroup,
+	cmdCh chan dummyCmd) bool {
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", testMqttHost, testMqttPort))
 	if err != nil {
 		panic(err)
 	}
 
-	go startAccepting(l)
-	close(readyCh)
-	<-ctx.Done()
-	logInfo("[MQTTD] Shutting down server")
-	l.Close()
-	wg.Done()
-}
+	context := dummyContext{
+		ctx:      ctx,
+		cmdCh:    cmdCh,
+		listener: l,
+		waitTime: 0,
+	}
 
-// Dummy server, with a context that will shut us down
-// modeMode means run as a Mode MQTT Server, not a generic one
-func dummyMQTTD(ctx context.Context, wg *sync.WaitGroup, mode publishMode) {
-	_pubMode = mode
-	readyCh := make(chan struct{})
+	if cmdCh != nil && ctx != nil {
+		panic(errors.New("dummy server cannot run with context.Context *and* a command channel"))
+	}
+	if cmdCh != nil {
+		go runCommandHandler(wg, &context)
+	} else {
+		// No command channel, so wait for the context to shut us down
+		go runWaitForCancel(wg, &context)
+	}
+	wg.Add(1)
+	go runServer(wg, &context, l)
 
-	go startServing(ctx, wg, readyCh)
-	// Wait to return until we've started the server
-	<-readyCh
+	return true
 }

--- a/v3/mqtt_mode.go
+++ b/v3/mqtt_mode.go
@@ -88,6 +88,8 @@ type (
 	}
 )
 
+var _ MqttDelegate = (*ModeMqttDelegate)(nil)
+
 func (dur ModeMqttOptDuration) apply(del *ModeMqttDelegate) {
 	del.responseTimeout = time.Duration(dur)
 }
@@ -183,7 +185,7 @@ func (del *ModeMqttDelegate) GetSendQueueSize() uint16 {
 	return del.sendQueueSize
 }
 
-func (del *ModeMqttDelegate) GetSubscriptions() []string {
+func (del *ModeMqttDelegate) Subscriptions() []string {
 	keys := make([]string, len(del.subscriptions))
 
 	i := 0

--- a/v3/mqtt_mode_test.go
+++ b/v3/mqtt_mode_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -40,25 +42,22 @@ func newModeMqttDelegate() (*ModeMqttDelegate, chan *DeviceCommand,
 }
 
 // Helper for some tests
-func testModeConnection(t *testing.T, delegate MqttDelegate,
-	expectError bool) *MqttClient {
-	client := NewMqttClient(modeMqttHost, modeMqttPort, nil, modeUseTLS,
-		delegate)
-	err := client.Connect()
+func testModeConnection(ctx context.Context, t *testing.T,
+	delegate *ModeMqttDelegate, expectError bool) *MqttClient {
+	client := NewMqttClient(modeMqttHost, modeMqttPort, delegate)
+	ctx, cancel := delegate.createContext()
+	defer cancel()
+	err := client.Connect(ctx)
 	if expectError {
-		if err == nil {
-			t.Errorf("Did not receive expected error")
-		}
-	} else if err != nil {
-		t.Errorf("Connect failed: %s", err)
+		assert.NotNil(t, err, "Did not receive expected error")
+	} else {
+		assert.Nil(t, err, "Connect failed")
 	}
 	isConnected := client.IsConnected()
 	if expectError {
-		if isConnected {
-			t.Errorf("IsConnected should not be true")
-		}
-	} else if !isConnected {
-		t.Errorf("IsConnected is false after connection")
+		assert.False(t, isConnected, "IsConnected should not be true")
+	} else {
+		assert.True(t, isConnected, "IsConnected is false after connection")
 	}
 
 	return client
@@ -68,18 +67,14 @@ func testModeConnection(t *testing.T, delegate MqttDelegate,
 func testModeWaitForPubAck(t *testing.T, delegate *ModeMqttDelegate,
 	expectTimeout bool) uint16 {
 	// Wait for the ack, or timeout
-	ctx, cancel := context.WithTimeout(context.Background(),
-		delegate.RequestTimeout())
+	ctx, cancel := delegate.createContext()
 	defer cancel()
 
 	// Block on the return channel or timeout
 	select {
-	case queueRes := <-delegate.QueueAckCh:
-		if queueRes.Err != nil {
-			t.Errorf("Queued request failed: %s", queueRes.Err)
-		} else {
-			return queueRes.PacketId
-		}
+	case queueResp := <-delegate.QueueAckCh:
+		assert.Nil(t, queueResp.Err, "Queued request failed")
+		return queueResp.PacketID
 	case <-ctx.Done():
 		if !expectTimeout {
 			t.Errorf("Ack response timeout: %s", ctx.Err())
@@ -95,19 +90,20 @@ func TestModeMqttClientConnection(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestModeMqttClientConnection: test bad user/pass")
 	badDelegate, _, _ := invalidModeMqttDelegate()
-	testModeConnection(t, badDelegate, true)
+	testModeConnection(ctx, t, badDelegate, true)
 
 	fmt.Println("TestModeMqttClientConnection: test good user/pass")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
+	// force the cancel before the wait
 	cancel()
 	wg.Wait()
 }
@@ -116,16 +112,16 @@ func TestModeMqttClientSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestModeMqttClientSubscribe")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
-	if err := client.Subscribe(); err != nil {
-		t.Errorf("failed to subscribe: %s", err)
+	client := testModeConnection(ctx, t, goodDelegate, false)
+	if errs := client.Subscribe(ctx); errs != nil {
+		t.Errorf("failed to subscribe: %s", errs)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -134,42 +130,37 @@ func TestModeMqttClientSubscribe(t *testing.T) {
 
 func TestModeMqttClientPing(t *testing.T) {
 	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPing")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
 
-	if err := client.Ping(); err != nil {
+	if err := client.Ping(ctx); err != nil {
 		t.Errorf("Ping send failed: %s", err)
 	}
 
-	// Wait for the ack, or timeout
-	ctx, cancel := context.WithTimeout(context.Background(),
-		client.delegate.RequestTimeout())
-	defer cancel()
-
 	// Block on the return channel or timeout
 	select {
-	case ret := <-goodDelegate.PingAckCh:
+	case resp := <-goodDelegate.PingAckCh:
 		// There's not really a way to return false, but, since it's bool, we'll
 		// check
-		if !ret {
-			t.Errorf("Ping response was false")
+		if resp.Err != nil {
+			t.Errorf("Ping response returned error: %s", resp.Err)
 		}
 	case <-ctx.Done():
 		t.Errorf("Ping response timeout: %s", ctx.Err())
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
-	serverCancel()
+	cancel()
 	wg.Wait()
 }
 
@@ -177,11 +168,11 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishEvent")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
@@ -192,32 +183,32 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 		Qos:       QOSAtMostOnce,
 	}
 
-	fmt.Println("Testing timeout for QOS 0")
-	var packetId uint16
-	packetId, err := client.PublishEvent(event)
+	var packetID uint16
+	packetID, err := client.PublishEvent(event)
 	if err != nil {
 		t.Errorf("Publish failed: %s", err)
 	}
 
-	returnId := testModeWaitForPubAck(t, goodDelegate, true)
-	if returnId != 0 {
+	fmt.Println("QOS 0. No ACK, so make sure we don't get one")
+	returnID := testModeWaitForPubAck(t, goodDelegate, true)
+	if returnID != 0 {
 		t.Errorf("Received an Ack for QOS 0")
 	}
 
 	fmt.Println("Testing ACK for QOS 1")
 	event.Qos = QOSAtLeastOnce
-	if packetId, err = client.PublishEvent(event); err != nil {
+	if packetID, err = client.PublishEvent(event); err != nil {
 		t.Errorf("Publish failed: %s", err)
 	}
 
-	returnId = testModeWaitForPubAck(t, goodDelegate, false)
+	returnID = testModeWaitForPubAck(t, goodDelegate, false)
 
-	if packetId != returnId {
+	if packetID != returnID {
 		t.Errorf("Send packet %d did not match Ack packet %d\n",
-			packetId, returnId)
+			packetID, returnID)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -226,15 +217,15 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 
 // Only test QOS 1 for this (QOS 0 was tested in PublishEvent, so, unless we
 // hit a bug with BulkData publishing, I think that's sufficient.
-func TestModeMqttClientPublishBulkData(t *testing.T) {
+func aTestModeMqttClientPublishBulkData(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishBulkData")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
@@ -242,16 +233,15 @@ func TestModeMqttClientPublishBulkData(t *testing.T) {
 	bulk := DeviceBulkData{
 		StreamID: "stream1",
 		Blob:     []byte("blob"),
-		Qos:      QOSAtLeastOnce,
+		Qos:      QOSAtMostOnce,
 	}
 	_, err := client.PublishBulkData(bulk)
-	if err != nil {
-		t.Errorf("PublishDeviceBulkData send failed: %s", err)
-	}
+	assert.Nil(t, err, "PublishDeviceBulkData send failed")
 
+	logInfo("[MQTT Test] disconnecting")
 	// From looking at the original session.go, I believe this was QOS0 (no
 	// ACK. So, once we send it, we're done
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -262,11 +252,11 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishKVUpdate")
 	goodDelegate, _, _ := newModeMqttDelegate()
-	client := testModeConnection(t, goodDelegate, false)
+	client := testModeConnection(ctx, t, goodDelegate, false)
 	if !client.IsConnected() {
 		t.Errorf("Lost connection")
 	}
@@ -278,47 +268,47 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 	}
 
 	// Set the value
-	packetId, err := client.PublishKeyValueUpdate(kvData)
+	packetID, err := client.PublishKeyValueUpdate(kvData)
 	if err != nil {
 		t.Errorf("PublishKeyValueUpdate send failed: %s", err)
 	}
 
-	returnId := testModeWaitForPubAck(t, goodDelegate, false)
-	if packetId != returnId {
+	returnID := testModeWaitForPubAck(t, goodDelegate, false)
+	if packetID != returnID {
 		t.Errorf("Send packet %d did not match Ack packet %d\n",
-			packetId, returnId)
+			packetID, returnID)
 	}
 
 	// Reload the value
 	kvData.Action = KVSyncActionReload
 
-	packetId, err = client.PublishKeyValueUpdate(kvData)
+	packetID, err = client.PublishKeyValueUpdate(kvData)
 	if err != nil {
 		t.Errorf("PublishKeyValueUpdate send failed: %s", err)
 	}
-	returnId = testModeWaitForPubAck(t, goodDelegate, true)
+	returnID = testModeWaitForPubAck(t, goodDelegate, true)
 
-	if packetId != returnId {
+	if packetID != returnID {
 		t.Errorf("Send packet %d did not match Ack packet %d\n",
-			packetId, returnId)
+			packetID, returnID)
 	}
 
 	// Delete the value
 	kvData.Action = KVSyncActionDelete
 
-	packetId, err = client.PublishKeyValueUpdate(kvData)
+	packetID, err = client.PublishKeyValueUpdate(kvData)
 	if err != nil {
 		t.Errorf("PublishKeyValueUpdate send failed: %s", err)
 	}
 
-	returnId = testModeWaitForPubAck(t, goodDelegate, true)
+	returnID = testModeWaitForPubAck(t, goodDelegate, true)
 
-	if packetId != returnId {
+	if packetID != returnID {
 		t.Errorf("Send packet %d did not match Ack packet %d\n",
-			packetId, returnId)
+			packetID, returnID)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -327,18 +317,21 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 
 // When we first connect and subscribe to the kv topic, we'll get a sync.
 // This is a good test to see that we're receiving.
-func TestModeMqttClientReceiveKvSync(t *testing.T) {
+func TestModeMqttClientReceiveKVSync(t *testing.T) {
 	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
+	cmdCh := make(chan dummyCmd)
 	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishKvUpdate)
+	dummyMQTTD(nil, &wg, cmdCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	fmt.Println("TestModeMqttClientReceiveKvSync")
 	goodDelegate, _, kvSyncChannel := newModeMqttDelegate()
-	client := NewMqttClient(modeMqttHost, modeMqttPort, nil, modeUseTLS,
-		goodDelegate)
-	client.Connect()
-
+	client := NewMqttClient(modeMqttHost, modeMqttPort, goodDelegate)
+	client.Connect(ctx)
+	// Tell the server to send a kv update
+	cmdCh <- publishKvCmd
 	// Start the listener
 	go goodDelegate.RunSubscriptionListener()
 
@@ -346,15 +339,13 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 		t.Errorf("Failed to connect")
 	}
 
-	if err := client.Subscribe(); err != nil {
+	if err := client.Subscribe(ctx); err != nil {
 		t.Errorf("failed to subscribe: %s", err)
 	}
 
-	// 3 seconds seems to be the correct timing for this test to cause the bulk
-	// sync to be sent by the server
-	d := time.Now().Add(3 * time.Second)
-	ctx, cancel := context.WithDeadline(context.Background(), d)
-	defer cancel()
+	d := time.Now().Add(2 * time.Second)
+	syncCtx, syncCancel := context.WithDeadline(context.Background(), d)
+	defer syncCancel()
 
 	receivedSubData := false
 	select {
@@ -363,7 +354,7 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 		fmt.Printf("Data: %v\n", kvSync)
 		receivedSubData = true
 		break
-	case <-ctx.Done():
+	case <-syncCtx.Done():
 		t.Errorf("Timed out waiting for command")
 	}
 
@@ -371,10 +362,10 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 		t.Errorf("Did not receive KV Sync")
 	}
 	fmt.Println("Exiting")
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
-	serverCancel()
+	cmdCh <- shutdownCmd
 	wg.Wait()
 }
 
@@ -382,16 +373,18 @@ func TestModeMqttClientReceiveKvSync(t *testing.T) {
 // initiate this automatically
 func TestModeMqttClientReceiveCommand(t *testing.T) {
 	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
+	cmdCh := make(chan dummyCmd)
 	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishCommand)
+	dummyMQTTD(nil, &wg, cmdCh)
 
 	fmt.Println("TestModeMqttClientReceiveCommand")
 	goodDelegate, cmdChannel, _ := newModeMqttDelegate()
-	client := NewMqttClient(modeMqttHost, modeMqttPort, nil, modeUseTLS,
-		goodDelegate)
-	client.Connect()
+	client := NewMqttClient(modeMqttHost, modeMqttPort, goodDelegate)
+	ctx, cancel := goodDelegate.createContext()
+	defer cancel()
+	client.Connect(ctx)
 
+	cmdCh <- publishCommandCmd
 	// Start the listener
 	go goodDelegate.RunSubscriptionListener()
 
@@ -399,15 +392,9 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 		t.Errorf("Failed to connect")
 	}
 
-	if err := client.Subscribe(); err != nil {
+	if err := client.Subscribe(ctx); err != nil {
 		t.Errorf("failed to subscribe: %s", err)
 	}
-
-	// 3 seconds seems to be the correct timing for this test to cause the bulk
-	// sync to be sent by the server
-	d := time.Now().Add(10 * time.Second)
-	ctx, cancel := context.WithDeadline(context.Background(), d)
-	defer cancel()
 
 	receivedSubData := false
 	select {
@@ -423,9 +410,9 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 		t.Errorf("Did not receive command")
 	}
 	fmt.Println("Exiting")
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
-	serverCancel()
+	cmdCh <- shutdownCmd
 	wg.Wait()
 }

--- a/v3/mqtt_mode_test.go
+++ b/v3/mqtt_mode_test.go
@@ -117,7 +117,7 @@ func TestModeMqttClientSubscribe(t *testing.T) {
 	fmt.Println("TestModeMqttClientSubscribe")
 	goodDelegate, _, _ := newModeMqttDelegate()
 	client := testModeConnection(ctx, t, goodDelegate, false)
-	errs := client.Subscribe(ctx)
+	errs := client.Subscribe(ctx, goodDelegate.Subscriptions())
 	assert.Nil(t, errs, "failed to subscribe")
 
 	assert.Nil(t, client.Disconnect(ctx), "error disconnecting")
@@ -292,7 +292,8 @@ func TestModeMqttClientReceiveKVSync(t *testing.T) {
 	goodDelegate.StartSubscriptionListener()
 
 	assert.True(t, client.IsConnected(), "Lost connection")
-	assert.Nil(t, client.Subscribe(ctx), "failed to subscribe")
+	assert.Nil(t, client.Subscribe(ctx, goodDelegate.Subscriptions()),
+		"failed to subscribe")
 
 	d := time.Now().Add(2 * time.Second)
 	syncCtx, syncCancel := context.WithDeadline(context.Background(), d)
@@ -339,7 +340,8 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 	goodDelegate.StartSubscriptionListener()
 
 	assert.True(t, client.IsConnected(), "Lost connection")
-	assert.Nil(t, client.Subscribe(ctx), "failed to subscribe")
+	assert.Nil(t, client.Subscribe(ctx, goodDelegate.Subscriptions()),
+		"failed to subscribe")
 
 	receivedSubData := false
 	select {

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -59,10 +59,6 @@ func (*TestMqttConfigDelegate) GetSendQueueSize() uint16 {
 	return uint16(0)
 }
 
-func (*TestMqttConfigDelegate) Subscriptions() []string {
-	return []string{"this", "and", "that"}
-}
-
 func newTestMqttDelegate() *TestMqttDelegate {
 	d := &TestMqttDelegate{
 		username:         "good",
@@ -70,6 +66,10 @@ func newTestMqttDelegate() *TestMqttDelegate {
 		receiveQueueSize: 2,
 		sendQueueSize:    2,
 		responseTimeout:  2 * time.Second,
+		subscriptions: []string{
+			fmt.Sprintf("/devices/%s/command", "foo"),
+			fmt.Sprintf("/devices/%s/kv", "bar"),
+		},
 	}
 
 	return d
@@ -108,16 +108,6 @@ func (del *TestMqttDelegate) GetReceiveQueueSize() uint16 {
 
 func (del *TestMqttDelegate) GetSendQueueSize() uint16 {
 	return del.sendQueueSize
-}
-
-func (del *TestMqttDelegate) Subscriptions() []string {
-	// could do this in the initializer, but then we can't bind it to this
-	// instance of the delegate
-	del.subscriptions = []string{
-		fmt.Sprintf("/devices/%s/command", del.username),
-		fmt.Sprintf("/devices/%s/kv", del.username),
-	}
-	return del.subscriptions
 }
 
 func (del *TestMqttDelegate) OnClose() {
@@ -244,7 +234,7 @@ func TestMqttClientSubscribe(t *testing.T) {
 	fmt.Println("TestMqttClientSubscribe")
 	goodDelegate := newTestMqttDelegate()
 	client := testConnection(ctx, t, goodDelegate, false)
-	if errs := client.Subscribe(ctx); errs != nil {
+	if errs := client.Subscribe(ctx, goodDelegate.subscriptions); errs != nil {
 		t.Errorf("failed to subscribe: %s", errs)
 	}
 

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -71,7 +71,7 @@ func (del *TestMqttDelegate) GetSendQueueSize() uint16 {
 	return del.sendQueueSize
 }
 
-func (del *TestMqttDelegate) GetSubscriptions() []string {
+func (del *TestMqttDelegate) Subscriptions() []string {
 	// could do this in the initializer, but then we can't bind it to this
 	// instance of the delegate
 	del.subscriptions = []string{
@@ -223,9 +223,7 @@ func sendPing(ctx context.Context, t *testing.T, client *MqttClient,
 	select {
 	case resp := <-del.pingAckCh:
 		logInfo("sendPing received ping response")
-		if resp.Err != nil {
-			t.Errorf("Ping response returned error: %s", resp.Err)
-		}
+		return resp.Err
 	case <-ctx.Done():
 		// If we're testing timeouts, this is expected. Not always test
 		// failure
@@ -260,8 +258,8 @@ func TestMqttClientPing(t *testing.T) {
 		cmdCh <- slowdownServerCmd
 		// Wait for the ack, but it will timeout
 		err := sendPing(ctx, t, client, delegate)
-		cmdCh <- resetServerCmd
 		assert.NotNil(t, err, "Received expected error")
+		cmdCh <- resetServerCmd
 		err = client.Disconnect(ctx)
 		assert.Nil(t, err, "error disconnecting")
 	})

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -2,59 +2,76 @@ package mode
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestMqttDelegate struct {
-	username      string
-	password      string
-	subscriptions []string
-	subRecvCh     chan MqttSubData
-	queueAckCh    chan MqttQueueResult
-	pingAckCh     chan bool
+	username         string
+	password         string
+	subscriptions    []string
+	receiveQueueSize uint16
+	sendQueueSize    uint16
+	responseTimeout  time.Duration
+	subRecvCh        <-chan MqttSubData
+	queueAckCh       <-chan MqttResponse
+	pingAckCh        <-chan MqttResponse
 }
 
 func newTestMqttDelegate() *TestMqttDelegate {
-	return &TestMqttDelegate{
-		// This is a user level password, which I can change, but it still
-		// shouldn't be in here. But, how else do you do automated tests in a
-		// public server?
-		username:   "good",
-		password:   "anything",
-		subRecvCh:  make(chan MqttSubData),
-		queueAckCh: make(chan MqttQueueResult),
-		pingAckCh:  make(chan bool),
+	d := &TestMqttDelegate{
+		username:         "good",
+		password:         "anything",
+		receiveQueueSize: 2,
+		sendQueueSize:    2,
+		responseTimeout:  2 * time.Second,
 	}
+
+	return d
 }
 
 func invalidTestMqttDelegate() TestMqttDelegate {
 	return TestMqttDelegate{
-		username:   "foo",
-		password:   "bar",
-		subRecvCh:  make(chan MqttSubData),
-		queueAckCh: make(chan MqttQueueResult),
-		pingAckCh:  make(chan bool),
+		username:         "foo",
+		password:         "bar",
+		receiveQueueSize: 2,
+		sendQueueSize:    2,
+		responseTimeout:  2 * time.Second,
 	}
 }
 
-func (del TestMqttDelegate) AuthInfo() (username string, password string) {
+func (del *TestMqttDelegate) TLSUsageAndConfiguration() (useTLS bool,
+	tlsConfig *tls.Config) {
+	return useTLS, nil
+}
+
+func (del *TestMqttDelegate) AuthInfo() (username string, password string) {
 	return del.username, del.password
 }
 
-func (del TestMqttDelegate) ReceiveChannels() (chan<- MqttSubData,
-	chan<- MqttQueueResult, chan<- bool) {
-	return del.subRecvCh, del.queueAckCh, del.pingAckCh
+func (del *TestMqttDelegate) SetReceiveChannels(subRecvCh <-chan MqttSubData,
+	queueAckCh <-chan MqttResponse,
+	pingAckCh <-chan MqttResponse) {
+	del.subRecvCh = subRecvCh
+	del.queueAckCh = queueAckCh
+	del.pingAckCh = pingAckCh
 }
 
-func (del TestMqttDelegate) RequestTimeout() time.Duration {
-	return requestTimeout
+func (del *TestMqttDelegate) GetReceiveQueueSize() uint16 {
+	return del.receiveQueueSize
 }
 
-func (del TestMqttDelegate) Subscriptions() []string {
+func (del *TestMqttDelegate) GetSendQueueSize() uint16 {
+	return del.sendQueueSize
+}
+
+func (del *TestMqttDelegate) GetSubscriptions() []string {
 	// could do this in the initializer, but then we can't bind it to this
 	// instance of the delegate
 	del.subscriptions = []string{
@@ -64,32 +81,28 @@ func (del TestMqttDelegate) Subscriptions() []string {
 	return del.subscriptions
 }
 
-func (del TestMqttDelegate) Close() {
-	// Nothing to do
+func (del *TestMqttDelegate) OnClose() {
 }
 
-func testConnection(t *testing.T, delegate MqttDelegate,
+func (del *TestMqttDelegate) createContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), del.responseTimeout)
+}
+
+func testConnection(ctx context.Context, t *testing.T, delegate MqttDelegate,
 	expectError bool) *MqttClient {
 
-	client := NewMqttClient(testMqttHost, testMqttPort, nil, useTLS,
-		delegate)
-	err := client.Connect()
+	client := NewMqttClient(testMqttHost, testMqttPort, delegate)
+	err := client.Connect(ctx)
 	if expectError {
-		if err == nil {
-			t.Errorf("Did not receive expected error")
-		} else {
-			fmt.Printf("Received expected error: %s\n", err)
-		}
-	} else if err != nil {
-		t.Errorf("Connect failed: %s", err)
+		assert.NotNil(t, err, "Did not receive expected error")
+	} else {
+		assert.Nil(t, err, "Connect failed")
 	}
 	isConnected := client.IsConnected()
 	if expectError {
-		if isConnected {
-			t.Errorf("IsConnected should not be true")
-		}
-	} else if !isConnected {
-		t.Errorf("IsConnected is false after connection")
+		assert.False(t, isConnected, "IsConnected should not be true")
+	} else {
+		assert.True(t, isConnected, "IsConnected is false after connection")
 	}
 
 	return client
@@ -99,19 +112,47 @@ func TestMqttClientConnection(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
-	fmt.Println("TestMqttClientConnction: test bad user/pass")
-	badDelegate := invalidTestMqttDelegate()
-	fmt.Println("Hitting server")
-	testConnection(t, badDelegate, true)
+	dummyMQTTD(ctx, &wg, nil)
 
-	fmt.Println("TestMqttClientConnction: test good user/pass")
-	goodDelegate := newTestMqttDelegate()
-	//client := testConnection(t, goodDelegate, false)
-	testConnection(t, goodDelegate, false)
-	// if client.Disconnect() != nil {
-	// 	t.Errorf("error disconnecting")
-	// }
+	t.Run("Fail to Connect bad user/pass", func(t *testing.T) {
+		badDelegate := invalidTestMqttDelegate()
+		testConnection(ctx, t, &badDelegate, true)
+	})
+	t.Run("Connect good user/pass", func(t *testing.T) {
+		goodDelegate := newTestMqttDelegate()
+		client := testConnection(ctx, t, goodDelegate, false)
+		assert.Nil(t, client.Disconnect(ctx), "error disconnecting")
+	})
+
+	cancel()
+	wg.Wait()
+}
+
+func TestMqttClientReconnect(t *testing.T) {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	dummyMQTTD(ctx, &wg, nil)
+	delegate := newTestMqttDelegate()
+
+	t.Run("Connect", func(t *testing.T) {
+		client := NewMqttClient(testMqttHost, testMqttPort, delegate)
+		err := client.Connect(ctx)
+		assert.Nil(t, err, "Failed to connect to client")
+		// Reconnect before disconnect:
+		err = client.Connect(ctx)
+		assert.NotNil(t, err, "Connect should fail if not Disconnected")
+		err = client.Disconnect(ctx)
+		assert.Nil(t, err, "Failed to disconnect from client")
+	})
+	t.Run("ReConnect", func(t *testing.T) {
+		// recreate the closed channels that were closed on OnClose()
+		client := NewMqttClient(testMqttHost, testMqttPort, delegate)
+		err := client.Connect(ctx)
+		assert.Nil(t, err, "Failed to connect to client")
+		err = client.Disconnect(ctx)
+		assert.Nil(t, err, "Failed to disconnect from client")
+	})
 
 	cancel()
 	wg.Wait()
@@ -121,15 +162,15 @@ func TestMqttClientSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 	fmt.Println("TestMqttClientSubscribe")
 	goodDelegate := newTestMqttDelegate()
-	client := testConnection(t, goodDelegate, false)
-	if err := client.Subscribe(); err != nil {
-		t.Errorf("failed to subscribe: %s", err)
+	client := testConnection(ctx, t, goodDelegate, false)
+	if errs := client.Subscribe(ctx); errs != nil {
+		t.Errorf("failed to subscribe: %s", errs)
 	}
 
-	if client.Disconnect() != nil {
+	if client.Disconnect(ctx) != nil {
 		t.Errorf("error disconnecting")
 	}
 	cancel()
@@ -138,79 +179,110 @@ func TestMqttClientSubscribe(t *testing.T) {
 
 func TestMqttClientPublish(t *testing.T) {
 	var wg sync.WaitGroup
-	ctx, cancel := context.WithCancel(context.Background())
+	delegate := newTestMqttDelegate()
+	ctx, cancel := delegate.createContext()
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, publishNone)
+	dummyMQTTD(ctx, &wg, nil)
 	fmt.Println("TestMqttClientPublish")
-	goodDelegate := newTestMqttDelegate()
-	client := testConnection(t, goodDelegate, false)
 
-	topic := fmt.Sprintf("/devices/%s/event", goodDelegate.username)
+	client := testConnection(ctx, t, delegate, false)
+
+	topic := fmt.Sprintf("/devices/%s/event", delegate.username)
 	event := DeviceEvent{
 		EventType: "CustomEvent",
 		EventData: map[string]interface{}{"key1": "val1"},
 		Qos:       QOSAtLeastOnce,
 	}
 	rawData, err := json.Marshal(event)
-	if err != nil {
-		t.Errorf("Publish send failed: %s", err)
-	}
-	packetId, err := client.Publish(event.Qos, topic, rawData)
-	if err != nil {
-		t.Errorf("Publish send failed: %s", err)
-	}
+	assert.Nil(t, err, "JSON marshaling failed")
+	packetID, err := client.Publish(ctx, event.Qos, topic, rawData)
+	assert.Nil(t, err, "Publish send failed")
 
 	// Wait for the ack.
-	ackData := <-goodDelegate.queueAckCh
-	if ackData.Err != nil {
-		t.Errorf("Publish ack failed: %s", ackData.Err)
-	}
-	if packetId != ackData.PacketId {
-		t.Errorf("Publish: Id and ack id do not match: %d, %d",
-			packetId, ackData.PacketId)
-	}
-
-	if client.Disconnect() != nil {
-		t.Errorf("error disconnecting")
+	select {
+	case ackData := <-delegate.queueAckCh:
+		assert.Nil(t, ackData.Err, "Publish ack failed")
+		assert.Equal(t, packetID, ackData.PacketID,
+			"Publish: ID and ack id do not match")
+		err = client.Disconnect(ctx)
+		assert.Nil(t, err, "error disconnecting")
+	case <-ctx.Done():
+		t.Errorf("Publish response never received")
 	}
 	cancel()
 	wg.Wait()
 }
 
-func TestMqttClientPing(t *testing.T) {
-	fmt.Println("TestMqttClientPing")
-	var wg sync.WaitGroup
-	serverCtx, serverCancel := context.WithCancel(context.Background())
-	wg.Add(1)
-	dummyMQTTD(serverCtx, &wg, publishNone)
-
-	goodDelegate := newTestMqttDelegate()
-	client := testConnection(t, goodDelegate, false)
-
-	if err := client.Ping(); err != nil {
-		t.Errorf("Ping send failed: %s", err)
+func sendPing(ctx context.Context, t *testing.T, client *MqttClient,
+	del *TestMqttDelegate) error {
+	if err := client.Ping(ctx); err != nil {
+		return err
 	}
-
-	// Wait for the ack, or timeout
-	ctx, cancel := context.WithTimeout(context.Background(),
-		client.delegate.RequestTimeout())
-	defer cancel()
 
 	// Block on the return channel or timeout
 	select {
-	case ret := <-goodDelegate.pingAckCh:
-		// There's not really a way to return false, but, since it's bool, we'll
-		// check
-		if !ret {
-			t.Errorf("Ping response was false")
+	case resp := <-del.pingAckCh:
+		logInfo("sendPing received ping response")
+		if resp.Err != nil {
+			t.Errorf("Ping response returned error: %s", resp.Err)
 		}
 	case <-ctx.Done():
-		t.Errorf("Ping response timeout: %s", ctx.Err())
+		// If we're testing timeouts, this is expected. Not always test
+		// failure
+		return fmt.Errorf("Timed out waiting for ping response")
 	}
 
-	if client.Disconnect() != nil {
-		t.Errorf("error disconnecting")
-	}
-	serverCancel()
+	return nil
+}
+
+func TestMqttClientPing(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cmdCh := make(chan dummyCmd)
+	dummyMQTTD(nil, &wg, cmdCh)
+
+	delegate := newTestMqttDelegate()
+
+	t.Run("Successful Ping", func(t *testing.T) {
+		ctx, cancel := delegate.createContext()
+		defer cancel()
+		client := testConnection(ctx, t, delegate, false)
+		err := sendPing(ctx, t, client, delegate)
+		assert.Nil(t, err, "ping failed")
+		err = client.Disconnect(ctx)
+		assert.Nil(t, err, "error disconnecting")
+	})
+
+	t.Run("Ping with Timeout", func(t *testing.T) {
+		ctx, cancel := delegate.createContext()
+		defer cancel()
+		client := testConnection(ctx, t, delegate, false)
+		cmdCh <- slowdownServerCmd
+		// Wait for the ack, but it will timeout
+		err := sendPing(ctx, t, client, delegate)
+		assert.NotNil(t, err, "Received expected error")
+		err = client.Disconnect(ctx)
+		assert.Nil(t, err, "error disconnecting")
+	})
+
+	t.Run("Ping with full queue", func(t *testing.T) {
+		// Create a new delegate which has a bigger ping response buffer
+		pingQueueSize := 6
+		queueDel := &TestMqttDelegate{
+			username:  "good",
+			password:  "anything",
+			subRecvCh: make(chan MqttSubData),
+			// in practice, this would be buffered
+			queueAckCh: make(chan MqttResponse),
+			pingAckCh:  make(chan MqttResponse, pingQueueSize),
+		}
+		ctx, cancel := queueDel.createContext()
+		defer cancel()
+		client := testConnection(ctx, t, queueDel, false)
+		assert.NotNil(t, client, "Failed to create a client and connect")
+	})
+
+	logInfo("Sending cancel to server")
+	cmdCh <- shutdownCmd
 	wg.Wait()
 }


### PR DESCRIPTION
After the first code block, Lawrence had suggestions for simplifying the code. I hope the code is simpler now.
 - Removed a mutex lock. Both the synchronous and asynchronous now send through a channel into one goroutine to send packets. So, no chance of more than one goroutine writing to the stream
 - No more creating a channel for each subscription. Originally, subscriptions were asynchronous, and creating channels for each subscribe was left from that. Removed it
 - Removed some API from the delegate. After testing out write timeouts, I think it's better just to use a context.Context in the API. The user can wrap it if they so desire.
 - Documentation
 - Changed up creation of the channels that are used by the delegate to receive data. Since sending on a closed channel panics, the MQTT client should close the channel. 
 - Moved some code around to allow disconnecting and reconnecting. Since this means closing a lot of the channels, the creation of channels moved into the MQTT client, rather than the delegate.
 - Gracefully handle disconnecting.

For testing:
 - Reorganized the dummy MQTT server to take commands while it's running and modified the tests to match. Fixed an intermittent bug with Disconnect (don't defer in a defer)
 - Dummy server handles multiple connections (but I haven't tested this yet).
 - Started using stretchr/testify. This was being used in the other test, so the dependency on this module already exists. We should switch entirely, but this PR is already huge.
 - 2 new tests in the vanilla client: Reconnect, and Ping queue overflow

There are failing tests, so there are more commits to come.