### PR TITLE
changes found during integration with factory_gateway

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -70,8 +70,9 @@ type (
 	// MqttSubData to send in the channel to the client when we receive data
 	// published for our subscription.
 	MqttSubData struct {
-		topic string
-		data  []byte
+		Topic       string
+		Data        []byte
+		ReceiveTime time.Time
 	}
 
 	// MqttResponse is result of an MQTT Request. Not all of these members will
@@ -130,6 +131,17 @@ type (
 		GetSendQueueSize() uint16
 	}
 
+	// MqttErrorDelegate is an optional delegate which allows the MqttClient
+	// a method of signaling errors that are not able to be communicated
+	// through the normal channels. See handling errors in the documentation.
+	MqttErrorDelegate interface {
+		// The buffer size of the error channel
+		GetErrorChannelSize() uint16
+
+		// Provides the delegate the channel to receive errors
+		SetErrorChannel(errCh chan error)
+	}
+
 	// MqttDelegate is the combined required interfaces that must be implemented
 	// to use the MqttClient. This is a convenience that the user can use to
 	// allow a single struct to implement all the required interfaces
@@ -150,16 +162,17 @@ type (
 	// a packet ID. This packet ID will be returned to the caller in the
 	// channel.
 	MqttClient struct {
-		mqttHost     string
-		mqttPort     int
-		authDelegate MqttAuthDelegate
-		recvDelegate MqttReceiverDelegate
-		confDelegate MqttConfigDelegate
-		conn         *mqttConn
-		wgSend       sync.WaitGroup
-		stopWriterCh chan struct{}
-		wgRecv       sync.WaitGroup
-		lastError    error
+		mqttHost      string
+		mqttPort      int
+		authDelegate  MqttAuthDelegate
+		recvDelegate  MqttReceiverDelegate
+		confDelegate  MqttConfigDelegate
+		errorDelegate MqttErrorDelegate
+		conn          *mqttConn
+		wgSend        sync.WaitGroup
+		stopWriterCh  chan struct{}
+		wgRecv        sync.WaitGroup
+		lastErrors    []error
 
 		delegateSubRecvCh chan MqttSubData
 	}
@@ -167,9 +180,9 @@ type (
 	// Delegate for the mqqtConn to call back to the MqttClient
 	mqttReceiver interface {
 		// Called by the connection when receiving publishes
-		handlePubReceive(*packet.PublishPacket)
+		handlePubReceive(pkt *packet.PublishPacket, receiveTime time.Time)
 		// Called by the connection when there is an error
-		setError(error)
+		appendError(error)
 	}
 
 	packetSendData struct {
@@ -212,6 +225,8 @@ type (
 		subRespCh  chan MqttResponse
 		pingRespCh chan MqttResponse
 		queueAckCh chan MqttResponse
+		// This is optional and may be nil
+		errCh chan error
 
 		mutex sync.Mutex
 	}
@@ -235,6 +250,12 @@ func WithMqttConfigDelegate(confDelegate MqttConfigDelegate) func(*MqttClient) {
 	}
 }
 
+func WithMqttErrorDelegate(errorDelegate MqttErrorDelegate) func(*MqttClient) {
+	return func(c *MqttClient) {
+		c.errorDelegate = errorDelegate
+	}
+}
+
 func WithMqttDelegate(delegate MqttDelegate) func(*MqttClient) {
 	return func(c *MqttClient) {
 		c.authDelegate = delegate
@@ -248,8 +269,9 @@ func WithMqttDelegate(delegate MqttDelegate) func(*MqttClient) {
 func NewMqttClient(mqttHost string, mqttPort int,
 	dels ...func(*MqttClient)) *MqttClient {
 	client := &MqttClient{
-		mqttHost: mqttHost,
-		mqttPort: mqttPort,
+		mqttHost:   mqttHost,
+		mqttPort:   mqttPort,
+		lastErrors: make([]error, 0, 5),
 	}
 
 	for _, del := range dels {
@@ -267,7 +289,7 @@ func NewMqttClient(mqttHost string, mqttPort int,
 // IsConnected will return true if we have a successfully CONNACK'ed response.
 //
 func (client *MqttClient) IsConnected() bool {
-	return client.conn.status == ConnectedNetworkStatus
+	return client.conn != nil && client.conn.status == ConnectedNetworkStatus
 }
 
 // GetLastActivity will return the time since the last send or
@@ -312,6 +334,11 @@ func (client *MqttClient) Connect(ctx context.Context) error {
 // the server closes the connection.
 // Note: We might want to wait, but order is important here.
 func (client *MqttClient) Disconnect(ctx context.Context) error {
+	if client.conn == nil {
+		// nothing to disconnect. Return
+		return nil
+	}
+
 	defer func() {
 		client.shutdownConnection()
 	}()
@@ -367,8 +394,7 @@ func (client *MqttClient) Subscribe(ctx context.Context,
 
 // Ping sends an MQTT PINGREQ event to the server. This is an asynchronous
 // call, so we will always return success if we were able to queue the message
-// for delivery. Any subsequent results will be sent on the delegate's
-// pingAckCh.
+// for delivery. Results will be sent on the delegate's pingAckCh
 func (client *MqttClient) Ping(ctx context.Context) error {
 
 	p := packet.NewPingreqPacket()
@@ -379,6 +405,24 @@ func (client *MqttClient) Ping(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// PingAndWait sends an MQTT PINGREQ event to the server and waits for the
+// response. If this method is used instead of the asynchronous Ping, user
+// should not be listening on the pingAckCh channel since this function may
+// timeout waiting for the response an error will be returned.
+func (client *MqttClient) PingAndWait(ctx context.Context) error {
+
+	p := packet.NewPingreqPacket()
+	respChan, err := client.conn.sendPacket(ctx, p)
+	if err != nil {
+		logError("[MQTT] failed to send packet: %s", err.Error())
+		return err
+	}
+
+	client.wgRecv.Add(1)
+	resp := client.receivePacket(ctx, respChan)
+	return resp.Err
 }
 
 // Publish sends an MQTT Publish event to subscribers on the specified
@@ -429,6 +473,12 @@ func (client *MqttClient) createMqttConnection() {
 	conn := newMqttConn(tlsConfig, client.mqttHost, client.mqttPort, useTLS,
 		queueAckCh, pingAckCh, sendQueueSize)
 
+	if client.errorDelegate != nil {
+		errCh := make(chan error, client.errorDelegate.GetErrorChannelSize())
+		client.errorDelegate.SetErrorChannel(errCh)
+		conn.errCh = errCh
+	}
+
 	client.conn = conn
 	conn.Receiver = client
 
@@ -469,6 +519,9 @@ func (client *MqttClient) shutdownConnection() {
 	close(client.conn.queueAckCh)
 	close(client.conn.pingRespCh)
 	close(client.delegateSubRecvCh)
+	if client.conn.errCh != nil {
+		close(client.conn.errCh)
+	}
 	client.conn = nil
 }
 
@@ -496,28 +549,48 @@ func (client *MqttClient) receivePacket(ctx context.Context,
 // Implementation of the delegate for mqttConn to handle publish from the
 // server on topics that we've subscribed to. We only unpack it and send it
 // to the caller
-func (client *MqttClient) handlePubReceive(p *packet.PublishPacket) {
+func (client *MqttClient) handlePubReceive(p *packet.PublishPacket,
+	receiveTime time.Time) {
 	logInfo("[MQTT] received message for topic %s", p.Message.Topic)
 
-	pubData := MqttSubData{p.Message.Topic, p.Message.Payload}
+	pubData := MqttSubData{p.Message.Topic, p.Message.Payload, receiveTime}
 
+	// If we have successfully queued the pub to the user
+	queueSuccess := false
 	select {
 	case client.delegateSubRecvCh <- pubData:
+		queueSuccess = true
 	default:
 		logError("Caller could not receive publish data. SubRecCh full?")
-		client.lastError = errors.New("SubRecCh channel is full")
+		client.conn.sendQueueingError(nil)
+	}
+	if queueSuccess && p.Message.QOS != packet.QOSAtMostOnce {
+		ackPkt := packet.NewPubackPacket()
+		ackPkt.PacketID = p.PacketID
+		// For everything except QOS2: if we have queued the message to the
+		// user, we consider that successfully published to us, so we attempt
+		// to send an ACK back to the server.
+		ctx, cancel := context.WithTimeout(context.Background(),
+			connResponseDeadline)
+		defer cancel()
+		if _, err := client.conn.queuePacket(ctx, ackPkt); err != nil {
+			client.conn.sendQueueingError(err)
+		}
 	}
 }
 
-func (client *MqttClient) GetLastError() error {
+// Returns the last errors, and then resets the errors. If there is no
+// error delegate or the error delegate's error channel is full, we "queue"
+// errors in a slice that can be fetched.
+func (client *MqttClient) GetLastErrors() []error {
 	defer func() {
-		client.lastError = nil
+		client.lastErrors = make([]error, 0, 5)
 	}()
-	return client.lastError
+	return client.lastErrors
 }
 
-func (client *MqttClient) setError(err error) {
-	client.lastError = err
+func (client *MqttClient) appendError(err error) {
+	client.lastErrors = append(client.lastErrors, err)
 }
 
 func newMqttConn(tlsConfig *tls.Config, mqttHost string,
@@ -529,14 +602,12 @@ func newMqttConn(tlsConfig *tls.Config, mqttHost string,
 	var err error
 	if useTLS {
 		if conn, err = tls.DialWithDialer(mqttDialer, "tcp", addr,
-			tlsConfig); err == nil {
-		} else {
+			tlsConfig); err != nil {
 			logError("MQTT TLS dialer failed: %s", err.Error())
 			return nil
 		}
 	} else {
-		if conn, err = mqttDialer.Dial("tcp", addr); err == nil {
-		} else {
+		if conn, err = mqttDialer.Dial("tcp", addr); err != nil {
 			logError("MQTT dialer failed: %s", err.Error())
 			return nil
 		}
@@ -648,34 +719,27 @@ func (conn *mqttConn) runPacketWriter(stopWriterCh chan struct{},
 		select {
 		case pktSendData := <-conn.directSendPktCh:
 			resultCh := pktSendData.resultCh
-			if conn.verifyPacketType(pktSendData.pkt.Type()) != directPacketSendType {
-				resultCh <- MqttResponse{
-					Err: errors.New("Packet type must be queued"),
-				}
-			} else {
-				resultCh <- MqttResponse{Err: conn.writePacket(pktSendData.pkt)}
-			}
+			resultCh <- MqttResponse{Err: conn.writePacket(pktSendData.pkt)}
 		case pktSendData := <-conn.queuedSendPktCh:
 			pktID := uint16(0)
 			if pktSendData.pkt.Type() == packet.PUBLISH {
 				pubPkt := pktSendData.pkt.(*packet.PublishPacket)
 				pktID = pubPkt.PacketID
 			}
-			// Get the packet ID, if any, for errors
+			// Get the packet ID, if any, for errors. This is a long lived channel, so
+			// it's possible to be full.
 			resultCh := pktSendData.resultCh
-			if conn.verifyPacketType(pktSendData.pkt.Type()) != queuedPacketSendType {
-				resultCh <- MqttResponse{
-					Err: errors.New("Packet type must be sent directly"),
-				}
-			} else {
-				err := conn.writePacket(pktSendData.pkt)
-				if err != nil {
-					// If there was an error sending, we can notify the caller
-					// immediately.
-					resultCh <- MqttResponse{
-						PacketID: pktID,
-						Err:      err,
-					}
+			err := conn.writePacket(pktSendData.pkt)
+			if err != nil {
+				// If there was an error sending, we can notify the caller
+				// immediately.
+				select {
+				case resultCh <- MqttResponse{
+					PacketID: pktID,
+					Err:      err,
+				}:
+				default:
+					conn.sendQueueingError(err)
 				}
 			}
 		case <-stopWriterCh:
@@ -714,7 +778,7 @@ func (conn *mqttConn) createResponseForPacket(p packet.Packet) MqttResponse {
 				err := errors.New("subscription rejected")
 				if i == 0 {
 					// If someone just checks Err of the response, at least
-					// they'll know that there was a failur
+					// they'll know that there was a failure
 					resp.Errs = append(resp.Errs, err)
 				}
 			}
@@ -737,13 +801,13 @@ func (conn *mqttConn) runPacketReader(wg *sync.WaitGroup) {
 		// this error and continue looping, if appropriate
 		conn.conn.SetReadDeadline(time.Now().Add(connResponseDeadline))
 		p, err := conn.stream.Read()
-		conn.lastActivity = time.Now()
 		if err != nil {
 			// Disconnect "responses" are EOF
 			if err == io.EOF || conn.status == DisconnectedNetworkStatus {
 				// Server disconnected. This happens for 2 reasons:
 				// 1. We initiated a disconnect
 				// 2. we don't ping, so the server assumed we're done
+				conn.status = DisconnectedNetworkStatus
 				logInfo("[MQTT] net.Conn disconnected: %s", err.Error())
 			} else {
 				// I/O Errors usually return this, so if it is, we can
@@ -761,10 +825,13 @@ func (conn *mqttConn) runPacketReader(wg *sync.WaitGroup) {
 			// exiting of this function (and wg.Done())
 			break
 		}
+		// Wait until here to set last activity, since disconnects and timeouts
+		// should be included as activity.
+		conn.lastActivity = time.Now()
 		if p.Type() == packet.PUBLISH {
 			// Incoming publish, received from our subscription.
 			pubPkt := p.(*packet.PublishPacket)
-			conn.Receiver.handlePubReceive(pubPkt)
+			conn.Receiver.handlePubReceive(pubPkt, time.Now())
 		} else {
 			// Everything besides publish and disconnect, so unpackage the
 			// packet data and send it to the appropriate channel
@@ -773,8 +840,7 @@ func (conn *mqttConn) runPacketReader(wg *sync.WaitGroup) {
 			select {
 			case respCh <- respData:
 			default:
-				logError("[MQTT] Response channel is full. Dropping return packets")
-				conn.Receiver.setError(errors.New("Response channel full. Dropping packet"))
+				conn.sendQueueingError(nil)
 			}
 		}
 	}
@@ -828,7 +894,6 @@ func (conn *mqttConn) verifyPacketType(pktType packet.Type) packetSendType {
 	case packet.PUBLISH, packet.PUBACK, packet.PINGREQ, packet.PINGRESP:
 		return queuedPacketSendType
 	default:
-		//
 		logError("[MQTT] Unhandled packet type: %s", pktType)
 		return unhandledPacketSendType
 	}
@@ -849,6 +914,25 @@ func (conn *mqttConn) getResponseChannel(pktType packet.Type) chan MqttResponse 
 	default:
 		logError("[MQTT] Unhandled packet type: %s", pktType)
 		return nil
+	}
+}
+
+func (conn *mqttConn) sendQueueingError(err error) {
+	if err == nil {
+		err = errors.New("Channel full. Sending on error channel")
+	}
+	if conn.errCh != nil {
+		select {
+		case conn.errCh <- err:
+			logInfo("Error Queued to delegate %d/%d", len(conn.errCh),
+				cap(conn.errCh))
+		default:
+			logInfo("Error delegate channel full. Check GetLastErrors")
+			conn.Receiver.appendError(err)
+		}
+	} else {
+		logInfo("No Error delegate channel. Check GetLastErrors")
+		conn.Receiver.appendError(err)
 	}
 }
 

--- a/v3/mqtt_mode.go
+++ b/v3/mqtt_mode.go
@@ -143,14 +143,14 @@ func (del *ModeMqttDelegate) runSubscriptionListener() {
 	for {
 		select {
 		case subData := <-del.SubRecvCh:
-			subBytes := subData.data
+			subBytes := subData.Data
 			// Determine which callback to call based on the topic
-			if handler, exists := del.subscriptions[subData.topic]; exists {
+			if handler, exists := del.subscriptions[subData.Topic]; exists {
 				if err := handler(subBytes); err != nil {
 					logError("Error in subscription handler: %s", err)
 				}
 			} else {
-				logError("No subscription handler for %s", subData.topic)
+				logError("No subscription handler for %s", subData.Topic)
 			}
 		case <-del.stopSubCh:
 			return

--- a/v3/mqtt_mode_test.go
+++ b/v3/mqtt_mode_test.go
@@ -91,7 +91,7 @@ func TestModeMqttClientConnection(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestModeMqttClientConnection: test bad user/pass")
 	badDelegate, _, _ := invalidModeMqttDelegate()
@@ -112,7 +112,7 @@ func TestModeMqttClientSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestModeMqttClientSubscribe")
 	goodDelegate, _, _ := newModeMqttDelegate()
@@ -130,7 +130,7 @@ func TestModeMqttClientPing(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPing")
 	goodDelegate, _, _ := newModeMqttDelegate()
@@ -157,7 +157,7 @@ func TestModeMqttClientPublishEvent(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishEvent")
 	goodDelegate, _, _ := newModeMqttDelegate()
@@ -198,7 +198,7 @@ func TestModeMqttClientPublishBulkData(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishBulkData")
 	goodDelegate, _, _ := newModeMqttDelegate()
@@ -226,7 +226,7 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	fmt.Println("TestMqttClientPublishKVUpdate")
 	goodDelegate, _, _ := newModeMqttDelegate()
@@ -274,9 +274,9 @@ func TestModeMqttClientPublishKVUpdate(t *testing.T) {
 // This is a good test to see that we're receiving.
 func TestModeMqttClientReceiveKVSync(t *testing.T) {
 	var wg sync.WaitGroup
-	cmdCh := make(chan dummyCmd)
+	cmdCh := make(chan DummyCmd)
 	wg.Add(1)
-	dummyMQTTD(nil, &wg, cmdCh)
+	DummyMQTTD(nil, &wg, cmdCh)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -287,7 +287,7 @@ func TestModeMqttClientReceiveKVSync(t *testing.T) {
 		WithMqttDelegate(goodDelegate))
 	client.Connect(ctx)
 	// Tell the server to send a kv update
-	cmdCh <- publishKvCmd
+	cmdCh <- PublishKvCmd
 	// Start the listener
 	goodDelegate.StartSubscriptionListener()
 
@@ -315,7 +315,7 @@ func TestModeMqttClientReceiveKVSync(t *testing.T) {
 	fmt.Println("Exiting")
 	assert.Nil(t, client.Disconnect(ctx), "error disconnecting")
 
-	cmdCh <- shutdownCmd
+	cmdCh <- ShutdownCmd
 	wg.Wait()
 }
 
@@ -323,9 +323,9 @@ func TestModeMqttClientReceiveKVSync(t *testing.T) {
 // initiate this automatically
 func TestModeMqttClientReceiveCommand(t *testing.T) {
 	var wg sync.WaitGroup
-	cmdCh := make(chan dummyCmd)
+	cmdCh := make(chan DummyCmd)
 	wg.Add(1)
-	dummyMQTTD(nil, &wg, cmdCh)
+	DummyMQTTD(nil, &wg, cmdCh)
 
 	fmt.Println("TestModeMqttClientReceiveCommand")
 	goodDelegate, cmdChannel, _ := newModeMqttDelegate()
@@ -335,7 +335,7 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 	defer cancel()
 	client.Connect(ctx)
 
-	cmdCh <- publishCommandCmd
+	cmdCh <- PublishCommandCmd
 	// Start the listener
 	goodDelegate.StartSubscriptionListener()
 
@@ -358,6 +358,6 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 	fmt.Println("Exiting")
 	assert.Nil(t, client.Disconnect(ctx), "error disconnecting")
 
-	cmdCh <- shutdownCmd
+	cmdCh <- ShutdownCmd
 	wg.Wait()
 }

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -32,6 +32,11 @@ type (
 	}
 	TestMqttConfigDelegate struct {
 	}
+
+	TestMqttErrorDelegate struct {
+		errorChBufSize uint16
+		errorCh        chan error
+	}
 )
 
 func (*TestMqttAuthDelegate) TLSUsageAndConfiguration() (useTLS bool, tlsConfig *tls.Config) {
@@ -59,12 +64,37 @@ func (*TestMqttConfigDelegate) GetSendQueueSize() uint16 {
 	return uint16(0)
 }
 
+func (ed *TestMqttErrorDelegate) GetErrorChannelSize() uint16 {
+	return ed.errorChBufSize
+}
+
+func (ed *TestMqttErrorDelegate) SetErrorChannel(errCh chan error) {
+	ed.errorCh = errCh
+}
+
 func newTestMqttDelegate() *TestMqttDelegate {
 	d := &TestMqttDelegate{
 		username:         "good",
 		password:         "anything",
 		receiveQueueSize: 2,
 		sendQueueSize:    2,
+		responseTimeout:  2 * time.Second,
+		subscriptions: []string{
+			fmt.Sprintf("/devices/%s/command", "foo"),
+			fmt.Sprintf("/devices/%s/kv", "bar"),
+		},
+	}
+
+	return d
+}
+
+func newTestMqttDelegateWithSettings(recvSize uint16,
+	sendSize uint16) *TestMqttDelegate {
+	d := &TestMqttDelegate{
+		username:         "good",
+		password:         "anything",
+		receiveQueueSize: recvSize,
+		sendQueueSize:    sendSize,
 		responseTimeout:  2 * time.Second,
 		subscriptions: []string{
 			fmt.Sprintf("/devices/%s/command", "foo"),
@@ -120,7 +150,7 @@ func (del *TestMqttDelegate) createContext() (context.Context, context.CancelFun
 func testConnection(ctx context.Context, t *testing.T, delegate MqttDelegate,
 	expectError bool) *MqttClient {
 
-	client := NewMqttClient(testMqttHost, testMqttPort,
+	client := NewMqttClient(TestMqttHost, TestMqttPort,
 		WithMqttDelegate(delegate))
 	err := client.Connect(ctx)
 	if expectError {
@@ -147,26 +177,26 @@ func TestCreateMqttClient(t *testing.T) {
 
 	t.Run("Incomplete implementations", func(t *testing.T) {
 		var client *MqttClient
-		client = NewMqttClient(testMqttHost, testMqttPort,
+		client = NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttAuthDelegate(authDel))
 		assert.Nil(t, client, "Incomplete delegate implementation succeeded")
-		client = NewMqttClient(testMqttHost, testMqttPort,
+		client = NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttReceiverDelegate(recvDel))
 		assert.Nil(t, client, "Incomplete delegate implementation succeeded")
-		client = NewMqttClient(testMqttHost, testMqttPort,
+		client = NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttConfigDelegate(confDel))
 		assert.Nil(t, client, "Incomplete delegate implementation succeeded")
-		client = NewMqttClient(testMqttHost, testMqttPort,
+		client = NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttAuthDelegate(authDel),
 			WithMqttConfigDelegate(confDel))
 		assert.Nil(t, client, "Incomplete delegate implementation succeeded")
 	})
 
 	t.Run("Good combinations", func(t *testing.T) {
-		client := NewMqttClient(testMqttHost, testMqttPort,
+		client := NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttDelegate(allInOne))
 		assert.NotNil(t, client, "Unexpected failure in creating client")
-		client = NewMqttClient(testMqttHost, testMqttPort,
+		client = NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttAuthDelegate(authDel),
 			WithMqttReceiverDelegate(recvDel),
 			WithMqttConfigDelegate(confDel))
@@ -178,7 +208,7 @@ func TestMqttClientConnection(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 
 	t.Run("Fail to Connect bad user/pass", func(t *testing.T) {
 		badDelegate := invalidTestMqttDelegate()
@@ -198,11 +228,11 @@ func TestMqttClientReconnect(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 	delegate := newTestMqttDelegate()
 
 	t.Run("Connect", func(t *testing.T) {
-		client := NewMqttClient(testMqttHost, testMqttPort,
+		client := NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttDelegate(delegate))
 		err := client.Connect(ctx)
 		assert.Nil(t, err, "Failed to connect to client")
@@ -214,7 +244,7 @@ func TestMqttClientReconnect(t *testing.T) {
 	})
 	t.Run("ReConnect", func(t *testing.T) {
 		// recreate the closed channels that were closed on OnClose()
-		client := NewMqttClient(testMqttHost, testMqttPort,
+		client := NewMqttClient(TestMqttHost, TestMqttPort,
 			WithMqttDelegate(delegate))
 		err := client.Connect(ctx)
 		assert.Nil(t, err, "Failed to connect to client")
@@ -230,7 +260,7 @@ func TestMqttClientSubscribe(t *testing.T) {
 	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 	fmt.Println("TestMqttClientSubscribe")
 	goodDelegate := newTestMqttDelegate()
 	client := testConnection(ctx, t, goodDelegate, false)
@@ -250,7 +280,7 @@ func TestMqttClientPublish(t *testing.T) {
 	delegate := newTestMqttDelegate()
 	ctx, cancel := delegate.createContext()
 	wg.Add(1)
-	dummyMQTTD(ctx, &wg, nil)
+	DummyMQTTD(ctx, &wg, nil)
 	fmt.Println("TestMqttClientPublish")
 
 	client := testConnection(ctx, t, delegate, false)
@@ -302,12 +332,12 @@ func sendPing(ctx context.Context, t *testing.T, client *MqttClient,
 func TestMqttClientPing(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
-	cmdCh := make(chan dummyCmd)
-	dummyMQTTD(nil, &wg, cmdCh)
+	cmdCh := make(chan DummyCmd)
+	DummyMQTTD(nil, &wg, cmdCh)
 
 	delegate := newTestMqttDelegate()
 
-	t.Run("Successful Ping", func(t *testing.T) {
+	t.Run("Successful Async Ping", func(t *testing.T) {
 		ctx, cancel := delegate.createContext()
 		defer cancel()
 		client := testConnection(ctx, t, delegate, false)
@@ -317,62 +347,138 @@ func TestMqttClientPing(t *testing.T) {
 		assert.Nil(t, err, "error disconnecting")
 	})
 
-	t.Run("Ping with Timeout", func(t *testing.T) {
+	t.Run("Successful sync Ping", func(t *testing.T) {
 		ctx, cancel := delegate.createContext()
 		defer cancel()
 		client := testConnection(ctx, t, delegate, false)
-		cmdCh <- slowdownServerCmd
-		// Wait for the ack, but it will timeout
-		err := sendPing(ctx, t, client, delegate)
-		assert.NotNil(t, err, "Received expected error")
-		cmdCh <- resetServerCmd
-		client.Disconnect(ctx)
-	})
-
-	t.Run("Ping with full queue", func(t *testing.T) {
-		// Create a new delegate which has a bigger ping response buffer
-		pingQueueSize := uint16(4)
-		queueDel := &TestMqttDelegate{
-			username:         "good",
-			password:         "anything",
-			receiveQueueSize: pingQueueSize,
-			sendQueueSize:    2,
-			// This test takes some round trips, so don't time out too soon
-			responseTimeout: 5 * time.Second,
-		}
-		ctx, cancel := queueDel.createContext()
-		defer cancel()
-		client := testConnection(ctx, t, queueDel, false)
-		assert.NotNil(t, client, "Failed to create a client and connect")
-
-		// Loop through and ping 6 times.
-		for i := uint16(0); i < pingQueueSize; i++ {
-			logInfo("Sending ping: %d", i)
-			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
-		}
-
-		// Wait for the round trip, but don't check...
-		timer := time.NewTimer(4 * time.Second)
-		<-timer.C
-
-		extraPings := int(2 * pingQueueSize)
-		numPings := 0
-		assert.Nil(t, client.GetLastError(), "Queue Already full?")
-		var err error = nil
-		// Since this is a synchronous, keep writing
-		for err == nil && numPings < extraPings {
-			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
-			timer = time.NewTimer(100 * time.Millisecond)
-			<-timer.C
-			err = client.GetLastError()
-		}
-		assert.NotNil(t, err, "Should have hit resonse queue error")
-
+		err := client.PingAndWait(ctx)
+		assert.Nil(t, err, "ping failed")
 		err = client.Disconnect(ctx)
 		assert.Nil(t, err, "error disconnecting")
 	})
 
+	t.Run("Ping with Timeout", func(t *testing.T) {
+		ctx, cancel := delegate.createContext()
+		defer cancel()
+		client := testConnection(ctx, t, delegate, false)
+		cmdCh <- SlowdownServerCmd
+		// Wait for the ack, but it will timeout
+		err := sendPing(ctx, t, client, delegate)
+		assert.NotNil(t, err, "Received expected error")
+		cmdCh <- ResetServerCmd
+		client.Disconnect(ctx)
+	})
+
 	logInfo("Sending shutdown to server")
-	cmdCh <- shutdownCmd
+	cmdCh <- ShutdownCmd
+	wg.Wait()
+}
+
+func waitForCondition(ctx context.Context, timeout time.Duration,
+	cond func() bool) bool {
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, timeout)
+	defer timeoutCancel()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	for !cond() {
+		select {
+		case <-ticker.C:
+		case <-timeoutCtx.Done():
+			return false
+		}
+	}
+	return true
+}
+
+func TestMqttErrorHandling(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cmdCh := make(chan DummyCmd)
+	DummyMQTTD(nil, &wg, cmdCh)
+	timeout := 4 * time.Second
+
+	queueSize := uint16(2)
+	delegate := newTestMqttDelegateWithSettings(queueSize, queueSize)
+
+	t.Run("TestNoErrorDelegate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		client := NewMqttClient(TestMqttHost, TestMqttPort,
+			WithMqttDelegate(delegate))
+		assert.Equal(t, len(client.GetLastErrors()), 0,
+			"Unexpected errors in last errors")
+		assert.Nil(t, client.Connect(ctx), "Failed to connect")
+		// Send some pings, but don't read the responses
+		for i := 0; i < int(queueSize); i++ {
+			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
+		}
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(delegate.pingAckCh) == 2
+		}), "Ping response queue never filled")
+
+		assert.Nil(t, client.Ping(ctx), "Send of ping failed")
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(client.GetLastErrors()) > 0
+		}), "GetLastErrors never populated")
+		assert.Nil(t, client.Disconnect(ctx), "Error in disconnect")
+	})
+
+	t.Run("TestErrorDelegate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		errorDelegate := TestMqttErrorDelegate{errorChBufSize: queueSize}
+		client := NewMqttClient(TestMqttHost, TestMqttPort,
+			WithMqttDelegate(delegate), WithMqttErrorDelegate(&errorDelegate))
+		assert.Nil(t, client.Connect(ctx), "Failed to connect")
+		// check that our error channel is empty
+		assert.Equal(t, len(errorDelegate.errorCh), 0,
+			"UnExpected errors in channela")
+		// Send some pings, but don't read the responses
+		for i := 0; i < int(queueSize); i++ {
+			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
+		}
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(delegate.pingAckCh) == 2
+		}), "Ping response queue never filled")
+
+		assert.Nil(t, client.Ping(ctx), "Send of ping failed")
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(errorDelegate.errorCh) > 0
+		}), "Error delegate  queue never filled")
+		assert.Nil(t, client.Disconnect(ctx), "Error in disconnect")
+	})
+
+	t.Run("TestErrorDelegateOverflow", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		errorDelegate := TestMqttErrorDelegate{errorChBufSize: queueSize}
+		client := NewMqttClient(TestMqttHost, TestMqttPort,
+			WithMqttDelegate(delegate), WithMqttErrorDelegate(&errorDelegate))
+		assert.Nil(t, client.Connect(ctx), "Failed to connect")
+		// check that our error channel is empty
+		assert.Equal(t, len(errorDelegate.errorCh), 0,
+			"Unexpected errors in channels")
+		assert.Equal(t, len(client.GetLastErrors()), 0,
+			"Unexpected errors in last errors")
+
+		// Fill two queues which are the same size, plus one overflow
+		for i := 0; i <= 2*int(queueSize); i++ {
+			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
+		}
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(delegate.pingAckCh) == 2
+		}), "Ping response queue never filled")
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(errorDelegate.errorCh) == 2
+		}), "Error delegate queue never filled")
+
+		assert.True(t, waitForCondition(ctx, timeout, func() bool {
+			return len(client.GetLastErrors()) > 0
+		}), "GetLastErrors never populated")
+
+		assert.Nil(t, client.Disconnect(ctx), "Error in disconnect")
+	})
+
+	logInfo("Sending shutdown to server")
+	cmdCh <- ShutdownCmd
 	wg.Wait()
 }


### PR DESCRIPTION
 - MqttSubData
   - members need to be exported.
   - added ReceivedTime 
 - made GetLastErrors return the last errors since the function was called. (might want to make this locked?)
 - Added an optional error delegate to take a channel to receive errors on
 - Added sending a PUBACK when receiving publishes. The MQTT server that the factory gateway connects to needs this, I believe.
 - Added a PingAndWait(). This waits for the ping instead of doing an asynchronous ping.
 - test fixes
 - better IsConnected test.
 - No restriction on what packets can be sent directly or queued. PINGREQ's can be queued or direct. We'll rely on the API to do the right thing.
 - Disconnect when not connected is a noop, not an error
 - properly record the lastActivity
 - Test MQTT server will send generic publishes on the topics a client is subscribed to.
 - Test MQTT server is now exported so you can test your clients with the server.
 - replaced a test: Instead of the flaky ping queue test, replaced it with a more thorough error handling test.