### PR TITLE
One fix, and race cleanup

### DIFF
--- a/v3/mqtt_mode.go
+++ b/v3/mqtt_mode.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	DefaultUseTLS    = false
+	DefaultUseTLS    = true
 	DefaultQueueSize = uint16(8)
 )
 

--- a/v3/mqtt_mode_test.go
+++ b/v3/mqtt_mode_test.go
@@ -32,7 +32,7 @@ func newModeMqttDelegate() *ModeMqttDelegate {
 		AuthToken: "v1.XXXXXXXXX",
 	}
 
-	return NewModeMqttDelegate(dc)
+	return NewModeMqttDelegate(dc, WithUseTLS(false))
 }
 
 // Helper for some tests
@@ -100,8 +100,8 @@ func TestModeMqttDelegate(t *testing.T) {
 		del := NewModeMqttDelegate(dc)
 
 		usage, conf := del.TLSUsageAndConfiguration()
-		// Default is not to use TSL
-		assert.Equal(t, DefaultUseTLS, usage, "Use TLS expected to be false")
+		// Default is not to use TLS
+		assert.Equal(t, DefaultUseTLS, usage, "Use TLS expected to be true")
 		assert.Nil(t, conf, "Expected no TLS config")
 		user, password := del.AuthInfo()
 		assert.Equal(t, fmt.Sprintf("%d", dc.DeviceID), user, "User did not match device ID")
@@ -130,18 +130,18 @@ func TestModeMqttDelegate(t *testing.T) {
 		sendQueueSize := uint16(2)
 
 		del := NewModeMqttDelegate(dc,
-			WithUseTLS(true),
+			WithUseTLS(false),
 			WithReceiveQueueSize(receiveQueueSize),
 			WithSendQueueSize(sendQueueSize),
 			WithAdditionalSubscription("additionalsub", nil),
 			WithAdditionalFormatSubscription("additional/%d/sub", nil))
 
 		usage, conf := del.TLSUsageAndConfiguration()
-		assert.True(t, usage, "Use TLS expected to be true")
+		assert.False(t, usage, "Use TLS expected to be false")
 		assert.Equal(t, dc.TLSConfig, conf, "Mismatch in TLSConfg")
 		_, password := del.AuthInfo()
 		assert.Empty(t, password,
-			"Should have empty password iif TLSClientAuth is true")
+			"Should have empty password if TLSClientAuth is true")
 		assert.Equal(t, del.GetReceiveQueueSize(), receiveQueueSize,
 			"Receive queue size did not match set value")
 		assert.Equal(t, del.GetSendQueueSize(), sendQueueSize,

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -275,6 +275,24 @@ func TestMqttClientSubscribe(t *testing.T) {
 	wg.Wait()
 }
 
+func TestMqttClientUnSubscribe(t *testing.T) {
+	// We only make sure we can send this and get a successful unsubscribe
+	// back.
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	wg.Add(1)
+	DummyMQTTD(ctx, &wg, nil)
+	fmt.Println("TestMqttClientUnsubscribe")
+	goodDelegate := newTestMqttDelegate()
+	client := testConnection(ctx, t, goodDelegate, false)
+	assert.Nil(t, client.Unubscribe(ctx, goodDelegate.subscriptions),
+		"Failed to unsubscribe")
+	assert.Nil(t, client.Disconnect(ctx), "error disconnecting")
+
+	cancel()
+	wg.Wait()
+}
+
 func TestMqttClientPublish(t *testing.T) {
 	var wg sync.WaitGroup
 	delegate := newTestMqttDelegate()


### PR DESCRIPTION
 - useTLS
useTLS wasn't working because it always returned false. There was a package level variable in v2, but, because it was a named return value, it used that, so it was always false.

Fixed that, and wrote a test to check all the overrides by options.

 - race fix: while running with test --race, some issues came up. Some in test code, and one minor status, but this should clear up the noise for higher level tests looking for race conditions.