### PR TITLE
fix unhandle error in v3

### DIFF
--- a/v3/mqtt_mode_test.go
+++ b/v3/mqtt_mode_test.go
@@ -353,7 +353,8 @@ func TestModeMqttClientReceiveKVSync(t *testing.T) {
 	goodDelegate := newModeMqttDelegate()
 	client := NewMqttClient(modeMqttHost, modeMqttPort,
 		WithMqttDelegate(goodDelegate))
-	client.Connect(ctx)
+	err := client.Connect(ctx)
+	assert.NoError(t, err)
 	// Tell the server to send a kv update
 	cmdCh <- PublishKvSync
 	// Start the listener
@@ -401,7 +402,8 @@ func TestModeMqttClientReceiveCommand(t *testing.T) {
 		WithMqttDelegate(goodDelegate))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	client.Connect(ctx)
+	err := client.Connect(ctx)
+	assert.NoError(t, err)
 
 	cmdCh <- PublishCommandCmd
 	// Start the listener

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -407,7 +407,8 @@ func TestMqttClientPing(t *testing.T) {
 		err := sendPing(ctx, t, client, delegate)
 		assert.NotNil(t, err, "Received expected error")
 		cmdCh <- ResetServerCmd
-		client.Disconnect(ctx)
+		err = client.Disconnect(ctx)
+		assert.NoError(t, err)
 	})
 
 	logInfo("Sending shutdown to server")
@@ -453,7 +454,9 @@ func TestMqttErrorHandling(t *testing.T) {
 			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
 		}
 		assert.True(t, waitForCondition(ctx, timeout, func() bool {
-			client.Ping(ctx)
+			if err := client.Ping(ctx); err != nil {
+				return false
+			}
 			return len(delegate.pingAckCh) == 2
 		}), "Ping response queue never filled")
 
@@ -479,13 +482,17 @@ func TestMqttErrorHandling(t *testing.T) {
 			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
 		}
 		assert.True(t, waitForCondition(ctx, timeout, func() bool {
-			client.Ping(ctx)
+			if err := client.Ping(ctx); err != nil {
+				return false
+			}
 			return len(delegate.pingAckCh) == 2
 		}), "Ping response queue never filled")
 
 		assert.Nil(t, client.Ping(ctx), "Send of ping failed")
 		assert.True(t, waitForCondition(ctx, timeout, func() bool {
-			client.Ping(ctx)
+			if err := client.Ping(ctx); err != nil {
+				return false
+			}
 			return len(errorDelegate.errorCh) > 0
 		}), "Error delegate  queue never filled")
 		assert.Nil(t, client.Disconnect(ctx), "Error in disconnect")
@@ -509,16 +516,22 @@ func TestMqttErrorHandling(t *testing.T) {
 			assert.Nil(t, client.Ping(ctx), "Send of ping failed")
 		}
 		assert.True(t, waitForCondition(ctx, timeout, func() bool {
-			client.Ping(ctx)
+			if err := client.Ping(ctx); err != nil {
+				return false
+			}
 			return len(delegate.pingAckCh) == 2
 		}), "Ping response queue never filled")
 		assert.True(t, waitForCondition(ctx, timeout, func() bool {
-			client.Ping(ctx)
+			if err := client.Ping(ctx); err != nil {
+				return false
+			}
 			return len(errorDelegate.errorCh) == 2
 		}), "Error delegate queue never filled")
 
 		assert.True(t, waitForCondition(ctx, timeout, func() bool {
-			client.Ping(ctx)
+			if err := client.Ping(ctx); err != nil {
+				return false
+			}
 			return len(client.TakeRemainingErrors()) > 0
 		}), "TakeRemainingErrors never populated")
 


### PR DESCRIPTION
The v3 test code looks unstable. Sometimes it fails or gets stuck. I thought that unhandled errors could affect the results and add error handling.