### PR TITLE
Decrease spewage

### DIFF
--- a/v3/mqtt_dummy.go
+++ b/v3/mqtt_dummy.go
@@ -51,6 +51,10 @@ var (
 	globalConf DummyConfig
 	packetID   uint32 = 1
 	kvRevision uint32 = 1
+
+	// DummyServerDelayDuration is the amount of time the server will wait before
+	// responding. This can be used to simulate a slow network
+	DummyServerDelayDuration = 3 * time.Second
 )
 
 type (
@@ -391,7 +395,7 @@ func runCommandHandler(wg *sync.WaitGroup, context *dummyContext) {
 			}
 			context.clientsMtx.RUnlock()
 		case SlowdownServerCmd:
-			context.setWaitTime(3 * time.Second)
+			context.setWaitTime(DummyServerDelayDuration)
 		case DisconnectCmd:
 			closeConnections(context)
 		case ResetServerCmd:

--- a/v3/mqtt_test.go
+++ b/v3/mqtt_test.go
@@ -341,7 +341,7 @@ func TestMqttClientPublish(t *testing.T) {
 		assert.Nil(t, err, "Publish send failed")
 		repubPacketID, err := client.Republish(ctx, event.Qos, topic, rawData,
 			packetID)
-		assert.Nil(t, err, "Publish send failed")
+		assert.Nil(t, err, "RePublish send failed")
 		assert.Equal(t, packetID, repubPacketID,
 			"Publish and Republish had different packet IDs")
 		err = client.Disconnect(ctx)


### PR DESCRIPTION
 - Removed logging on every publish. This was useful early in debugging, but it's too much for regular usage.
 - Removed harmless error when we receive the unsub ACK. Since we only needed the packet ID in the ACK, it was harmless to not handle the packet type. But, now we can handle it and avoid the warning.

Also:
 - Exported a DummyServerDelayDuration so tests can adjust the amount of time for slow network responses.