### PR TITLE
fix: extend timeout for 3G/LTE network

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	mqttConnectTimeout   = time.Second * 10
-	connResponseDeadline = time.Millisecond * 500
+	connResponseDeadline = time.Second * 10
 )
 
 var mqttDialer = &net.Dialer{Timeout: mqttConnectTimeout}


### PR DESCRIPTION
The original value 500 ms is too short to upload bulk data with 3G/LTE network.