### PR TITLE
The server is too fast!

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -329,13 +329,14 @@ func (client *MqttClient) Connect(ctx context.Context) error {
 	p.Password = pwd
 	p.CleanSession = true
 
+	client.wgRecv.Add(1)
 	respChan, err := client.getConn().sendPacket(ctx, p)
 	if err != nil {
 		logError("[MQTT] failed to send packet: %s", err.Error())
+		client.wgRecv.Done()
 		return err
 	}
 
-	client.wgRecv.Add(1)
 	resp := client.receivePacket(ctx, respChan)
 	if resp.Err != nil {
 		client.getConn().setStatus(DisconnectedNetworkStatus)

--- a/v3/mqtt_dummy.go
+++ b/v3/mqtt_dummy.go
@@ -213,6 +213,13 @@ func handleSession(context *DummyContext, client *DummyClient) {
 func getResponsePacket(client *DummyClient, pktBytes []byte,
 	pktLen int) (pkt packet.Packet, keepConn bool) {
 	keepConn = true
+	// In the test cases, the server occasionally sends back the response before the client
+	// is ready. There will always be a race condition, although a round trip through the network
+	// should be plenty of time for the client to do the few things it takes to start listening
+	// for the response. But, when everything is in the same process, and the network is the
+	// loopback, the client needs a little bit more time. So, sleep for a tiny bit to give the
+	// client the time to execute a couple more instructions.
+	//time.Sleep(time.Millisecond)
 	l, ty := packet.DetectPacket(pktBytes[0:pktLen])
 	if ty == packet.CONNECT {
 		inPkt := packet.NewConnectPacket()


### PR DESCRIPTION
In some iterations, during the time we send the MQTT packet, and the time we start listening for the response, the server has already responded.

Aside from the mqtt_packet library, there is a switch statement, which could be done beforehand, and a WaitGroup.Add. The switch statement is not expensive, but moving the Add reduces the number of instructions so the client can start listening for the response before the server has a chance to send it.

Of course, adding a delay in the server would also solve the problem.