### PR TITLE
The server is too fast!

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -687,10 +687,12 @@ func newMqttConn(tlsConfig *tls.Config, mqttHost string,
 		// we will lose packets.
 		queuedSendPktCh: make(chan packetSendData, outgoingQueueSize),
 
-		// Connection requests are blocking, so no buffer
-		connRespCh:  make(chan MqttResponse),
-		subRespCh:   make(chan MqttResponse),
-		unsubRespCh: make(chan MqttResponse),
+		// These are synchronous requests, so we send the packet, then wait for the response. But,
+		// we create a buffer of 1, so if the response is received before we start listening
+		// to this channel, it won't be dropped
+		connRespCh:  make(chan MqttResponse, 1),
+		subRespCh:   make(chan MqttResponse, 1),
+		unsubRespCh: make(chan MqttResponse, 1),
 
 		// These are passed to us by the client, with a buffer sized specified
 		// by the delegate, so it is the delegate's responsibility to set the


### PR DESCRIPTION
In some iterations, during the time we send the MQTT packet, and the time we start listening for the response, the server has already responded.

The client spends too much time calling WaitGroup.Add(). This delay means that the goroutine listening for the server response will write to an unbuffered channel before the client is listening to it.

So, for the synchronous calls (connection, subscribe, and unsubscribe), the response channel now has a buffer of 1. So, if the response is written to the channel before we can read it, it won't get dropped into the error queue.