### PR TITLE
Fix to access nil connection

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -755,8 +755,8 @@ func (conn *mqttConn) setStatus(status NetworkStatus) {
 }
 
 func (conn *mqttConn) getStatus() NetworkStatus {
-	//statusMutex.RLock()
-	//defer statusMutex.RUnlock()
+	conn.statusMutex.Lock()
+	defer conn.statusMutex.Unlock()
 	return conn.status
 }
 

--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -292,7 +292,9 @@ func NewMqttClient(mqttHost string, mqttPort int,
 // IsConnected will return true if we have a successfully CONNACK'ed response.
 //
 func (client *MqttClient) IsConnected() bool {
-	return client.getConn() != nil && client.getStatus() == ConnectedNetworkStatus
+	client.connMtx.Lock()
+	defer client.connMtx.Unlock()
+	return client.conn != nil && client.conn.getStatus() == ConnectedNetworkStatus
 }
 
 func (client *MqttClient) setConn(c *mqttConn) {
@@ -755,8 +757,8 @@ func (conn *mqttConn) setStatus(status NetworkStatus) {
 }
 
 func (conn *mqttConn) getStatus() NetworkStatus {
-	conn.statusMutex.Lock()
-	defer conn.statusMutex.Unlock()
+	conn.statusMutex.RLock()
+	defer conn.statusMutex.RUnlock()
 	return conn.status
 }
 


### PR DESCRIPTION
I found following panics on testing this improvement (https://github.com/moderepo/go-gw-common/pull/15).

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa8 pc=0x5d27f7]

goroutine 6966 [running]:
github.com/moderepo/device-sdk-go/v3.(*mqttConn).getStatus(0xc00062a628)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:712 +0x37
github.com/moderepo/device-sdk-go/v3.(*MqttClient).IsConnected(0xc06289e4a7a18fe0)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:294 +0x38
github.com/moderepo/go-gw-common/mccc.(*Communicator).IsConnected(...)
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:620
github.com/moderepo/go-gw-common/mccc.(*Communicator).runRetryLoop.func1()
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:1059 +0xee
created by github.com/moderepo/go-gw-common/mccc.(*Communicator).runRetryLoop
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:1048 +0x9d
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa8 pc=0x5d27f7]

goroutine 9350 [running]:
github.com/moderepo/device-sdk-go/v3.(*mqttConn).getStatus(0xc000d22628)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:712 +0x37
github.com/moderepo/device-sdk-go/v3.(*MqttClient).IsConnected(0xc06289e4ab01ea84)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:294 +0x38
github.com/moderepo/go-gw-common/mccc.(*Communicator).IsConnected(...)
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:620
github.com/moderepo/go-gw-common/mccc.(*Communicator).runRetryLoop.func1()
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:1059 +0xee
created by github.com/moderepo/go-gw-common/mccc.(*Communicator).runRetryLoop
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:1048 +0x9d
```

```
panic: send on closed channel

goroutine 5150 [running]:
github.com/moderepo/device-sdk-go/v3.(*mqttConn).queuePacket(0xc00007d520, {0x689868, 0xc000afdec0}, {0x68ac18, 0xc0018fd9c0})
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:755 +0x207
github.com/moderepo/device-sdk-go/v3.(*MqttClient).publishWithID(0xc00035de70, {0x689868, 0xc000afdec0}, 0x4b0f0a, {0xc000e1f0b0, 0x13}, {0xc000e11e90, 0x23, 0x30}, 0x0)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:508 +0x15c
github.com/moderepo/device-sdk-go/v3.(*MqttClient).Publish(...)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:480
github.com/moderepo/go-gw-common/mccc.(*Communicator).Publish(0xc0001362c0, {0x689868, 0xc000afdec0}, 0x1, {0xc000e1f0b0, 0x5fc380}, {0xc000e11e90, 0x0, 0x0})
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:809 +0x16b
main.main.func2(0x0)
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/examples/client/main.go:120 +0x203
created by main.main
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/examples/client/main.go:99 +0x273
panic: send on closed channel

goroutine 5148 [running]:
github.com/moderepo/device-sdk-go/v3.(*mqttConn).queuePacket(0xc00007d520, {0x689868, 0xc0008b3f20}, {0x68ac18, 0xc0018fd940})
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:755 +0x207
github.com/moderepo/device-sdk-go/v3.(*MqttClient).publishWithID(0xc00035be70, {0x689868, 0xc0008b3f20}, 0x4b0f0a, {0xc000e1f080, 0x13}, {0xc000e11e30, 0x23, 0x30}, 0x0)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:508 +0x15c
github.com/moderepo/device-sdk-go/v3.(*MqttClient).Publish(...)
        /home/nomoto/src/github.com/moderepo/device-sdk-go/v3/mqtt.go:480
github.com/moderepo/go-gw-common/mccc.(*Communicator).Publish(0xc0001362c0, {0x689868, 0xc0008b3f20}, 0x1, {0xc000e1f080, 0x0}, {0xc000e11e30, 0x0, 0x0})
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/connection.go:809 +0x16b
main.main.func2(0x0)
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/examples/client/main.go:120 +0x203
created by main.main
        /home/nomoto/src/github.com/moderepo/go-gw-common/mccc/examples/client/main.go:99 +0x273
```

These are happened with shutdown connection.
I've improve the way of mutex more strict a little.

- Adding mutex on `shutdownConnection`
- Wrapping functions for using `conn` with mutex on `MqttClient`

Maybe it's improved. Please let me know your concern.
