### PR TITLE
Add to check type for avoiding panic

### DIFF
--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -271,7 +271,6 @@ func WithMqttDelegate(delegate MqttDelegate) func(*MqttClient) {
 // not connected, and you need to create a new client to reconnect.
 func NewMqttClient(mqttHost string, mqttPort int,
 	dels ...func(*MqttClient)) *MqttClient {
-	fmt.Println("--------------------------------------------------- start!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 	client := &MqttClient{
 		mqttHost:   mqttHost,
 		mqttPort:   mqttPort,

--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -962,8 +962,7 @@ func (conn *mqttConn) runPacketReader(wg *sync.WaitGroup) {
 			} else {
 				// I/O Errors usually return this, so if it is, we can
 				// figure out what to do next
-				opError := err.(*net.OpError)
-				if opError != nil {
+				if opError, ok := err.(*net.OpError); ok {
 					if os.IsTimeout(opError.Err) {
 						// No problem - read deadline just exceeded
 						continue

--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -271,6 +271,7 @@ func WithMqttDelegate(delegate MqttDelegate) func(*MqttClient) {
 // not connected, and you need to create a new client to reconnect.
 func NewMqttClient(mqttHost string, mqttPort int,
 	dels ...func(*MqttClient)) *MqttClient {
+	fmt.Println("--------------------------------------------------- start!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 	client := &MqttClient{
 		mqttHost:   mqttHost,
 		mqttPort:   mqttPort,
@@ -968,7 +969,7 @@ func (conn *mqttConn) runPacketReader(wg *sync.WaitGroup) {
 						continue
 					}
 				}
-				logError("[MQTT] failed to read packet: %s", err.Error())
+				logError("[MQTT] failed to read packet: %v", err)
 			}
 			// The signal to the caller that disconnect was complete is the
 			// exiting of this function (and wg.Done())


### PR DESCRIPTION
When (maybe) MQTT has something wrong issue, `conn.stream.Read` returns error not only `net.OpError` but also other errors like `errors.errorString`.

Just in case, I've only checked which this sdk can work with sensor gateway. 