### PR TITLE
MQTT over WebSocket support

### DIFF
--- a/v3/examples/websocket_echo/main.go
+++ b/v3/examples/websocket_echo/main.go
@@ -1,0 +1,151 @@
+/*
+In this example, the device sends an "echo" event whenever it receives a "doEcho"
+command.
+*/
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/moderepo/device-sdk-go/v3"
+)
+
+var (
+	// Set these to the mode server
+	modeMqttHost = "localhost"
+	modeMqttPort = 21883
+)
+
+const (
+	operationTimeout = 5 * time.Second
+)
+
+func runPingLoop(ctx context.Context, wg *sync.WaitGroup, client *mode.MqttClient) {
+	// Ping on an interval (if necessary)
+	pingTimer := time.NewTicker(2 * operationTimeout)
+	fmt.Println("[Echo] start pinger loop.")
+
+	go func() {
+		defer wg.Done()
+		defer fmt.Println("[Echo] stop pinger loop.")
+		defer pingTimer.Stop()
+		for {
+			pingCtx, pingCancel := context.WithTimeout(ctx, operationTimeout)
+			if err := client.PingAndWait(pingCtx); err != nil {
+				fmt.Printf("[Echo] Failed ping %v\n", err)
+			}
+			pingCancel()
+			select {
+			case <-pingTimer.C:
+			case <-ctx.Done():
+				return
+			}
+
+		}
+	}()
+}
+
+func waitForAck(ctx context.Context, delegate *mode.ModeMqttDelegate) uint16 {
+	// Block on the return channel or timeout
+	select {
+	case queueResp := <-delegate.QueueAckCh:
+		if queueResp.Err != nil {
+			fmt.Printf("Queued request failed: %s\n", queueResp.Err)
+		} else {
+			return queueResp.PacketID
+		}
+	case <-ctx.Done():
+		fmt.Printf("Ack response timeout: %s\n", ctx.Err())
+	}
+
+	return 0
+}
+
+func receiveCommands(ctx context.Context, delegate *mode.ModeMqttDelegate, client *mode.MqttClient) {
+	cmdChannel := delegate.GetCommandChannel()
+	for {
+		select {
+		case cmd := <-cmdChannel:
+			fmt.Printf("[Echo] Received command: %s\n", cmd.Action)
+			switch cmd.Action {
+			case "doEcho":
+				var params struct {
+					Msg string `json:"msg"`
+				}
+
+				if err := cmd.BindParameters(&params); err != nil {
+					fmt.Printf("[Echo] Failed to bind command parameters: %s\n", err.Error())
+					return
+				}
+
+				event := mode.DeviceEvent{
+					EventType: "echo",
+					EventData: map[string]interface{}{"msg": params.Msg},
+					Qos:       mode.QOSAtLeastOnce,
+				}
+				pubCtx, pubCancel := context.WithTimeout(ctx, operationTimeout)
+				_, err := client.PublishEvent(pubCtx, event)
+				if err != nil {
+					fmt.Printf("[Echo] Failed to send event: %s\n", err.Error())
+				}
+				waitForAck(pubCtx, delegate)
+				fmt.Println("[Echo] ACK received from echo")
+				pubCancel()
+			}
+		case <-ctx.Done():
+			break
+		}
+	}
+}
+
+func main() {
+	var pingWg sync.WaitGroup
+
+	dc := &mode.DeviceContext{
+		DeviceID:  0000,
+		AuthToken: "v1.xxxxxxxx",
+	}
+
+	delegate := mode.NewModeMqttDelegate(dc)
+	delegate.UseTLS = false
+
+	client := mode.NewMqttClient(modeMqttHost, modeMqttPort, mode.WithMqttDelegate(delegate), mode.WithUseWebSocket(true))
+	ctx, cancel := context.WithTimeout(context.Background(), operationTimeout)
+	if err := client.Connect(ctx); err != nil {
+		fmt.Printf("[Echo] Failed to connect to %s:%d\n", modeMqttHost, modeMqttPort)
+		os.Exit(1)
+	}
+	cancel()
+
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	// Start listening for the subscriptions before we subscribe and listen on
+	// the channel that the listener sends to
+	go delegate.StartSubscriptionListener()
+	go receiveCommands(loopCtx, delegate, client)
+	ctx, cancel = context.WithTimeout(context.Background(), operationTimeout)
+	if err := client.Subscribe(ctx, delegate.Subscriptions()); err != nil {
+		fmt.Printf("[Echo] failed to subscribe: %s\n", err)
+	}
+	cancel()
+
+	// Run the ping loop to keep alive while we wait for the "doEcho" command
+	pingWg.Add(1)
+	runPingLoop(loopCtx, &pingWg, client)
+
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGTERM, syscall.SIGINT)
+
+	sig := <-c
+	fmt.Printf("[Echo] Received signal [%v]; shutting down...\n", sig)
+	loopCancel()
+	pingWg.Wait()
+	ctx, cancel = context.WithTimeout(context.Background(), operationTimeout)
+	client.Disconnect(ctx)
+	cancel()
+}

--- a/v3/go.mod
+++ b/v3/go.mod
@@ -3,6 +3,7 @@ module github.com/moderepo/device-sdk-go/v3
 go 1.14
 
 require (
+	github.com/gorilla/websocket v1.5.0
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 )

--- a/v3/go.sum
+++ b/v3/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -711,7 +711,7 @@ func (client *MqttClient) appendError(err error) {
 }
 
 func newMqttConn(tlsConfig *tls.Config, mqttHost string,
-	mqttPort int, useTLS bool, useWebSocket bool, queueAckCh chan MqttResponse,
+	mqttPort int, useTLS, useWebSocket bool, queueAckCh chan MqttResponse,
 	pingAckCh chan MqttResponse, outgoingQueueSize uint16) *mqttConn {
 
 	addr := fmt.Sprintf("%s:%d", mqttHost, mqttPort)

--- a/v3/mqtt.go
+++ b/v3/mqtt.go
@@ -723,7 +723,7 @@ func newMqttConn(tlsConfig *tls.Config, mqttHost string,
 		if !useTLS {
 			network = "ws"
 		}
-		if conn, err = websocket.Dial(network, addr); err != nil {
+		if conn, err = websocket.Dial(network, addr, tlsConfig); err != nil {
 			logError("WebSocket dialer failed: %s", err.Error())
 			return nil
 		}

--- a/v3/rest.go
+++ b/v3/rest.go
@@ -22,6 +22,7 @@ var (
 	httpTransport = &http.Transport{
 		MaxIdleConnsPerHost: defaultHTTPKeepAliveMaxConn,
 		IdleConnTimeout:     defaultHTTPKeepAliveTimeout,
+		Proxy:               http.ProxyFromEnvironment,
 	}
 
 	httpClient = &http.Client{

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -1,0 +1,78 @@
+package websocket
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type (
+	// Conn is a wrapper struct for WebSocket connection.
+	Conn struct {
+		*websocket.Conn
+		readBuffer bytes.Buffer
+	}
+)
+
+var _ net.Conn = (*Conn)(nil)
+
+// Read message from WebSocket.
+func (c Conn) Read(b []byte) (n int, err error) {
+	// If there is remaining in the buffer, return it first.
+	if c.readBuffer.Len() > 0 {
+		return c.readBuffer.Read(b)
+	}
+
+	// Read buffer is empty. Read from the underlying connection.
+	// If the broker is idle and no data is ready, ReadMessage will return timeout error after the deadline.
+	// Gorilla's SetReadDeadline is different from net.Conn's SetReadDeadline.
+	// After a read has timed out, the websocket connection state is corrupt and all future reads will return an error.
+	// As a workaround, I set a zero value for deadline implicitly so that reads will not time out.
+	if err := c.Conn.SetReadDeadline(time.Time{}); err != nil {
+		return 0, err
+	}
+	_, reader, err := c.Conn.NextReader()
+	if err != nil {
+		return 0, err
+	}
+
+	// Buffer the message (=MQTT packet) because the reader may not have enough read buffer capacity.
+	if _, err := c.readBuffer.ReadFrom(reader); err != nil {
+		return 0, err
+	}
+
+	return c.readBuffer.Read(b)
+}
+
+// Write message to WebSocket.
+func (c Conn) Write(b []byte) (n int, err error) {
+	if err := c.Conn.WriteMessage(websocket.BinaryMessage, b); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// SetDeadline both read and write.
+func (c Conn) SetDeadline(t time.Time) error {
+	if err := c.Conn.SetReadDeadline(t); err != nil {
+		return err
+	}
+	if err := c.Conn.SetWriteDeadline(t); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Dial creates a new WebSocket connection.
+func Dial(network, addr string) (net.Conn, error) {
+	urlStr := fmt.Sprintf("%s://%s", network, addr)
+	c, _, err := websocket.DefaultDialer.Dial(urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Conn{Conn: c}, nil
+}

--- a/v3/websocket/websocket.go
+++ b/v3/websocket/websocket.go
@@ -2,8 +2,10 @@ package websocket
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -67,9 +69,15 @@ func (c Conn) SetDeadline(t time.Time) error {
 }
 
 // Dial creates a new WebSocket connection.
-func Dial(network, addr string) (net.Conn, error) {
+func Dial(network, addr string, tlsConfig *tls.Config) (net.Conn, error) {
+	dialer := &websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:  tlsConfig,
+	}
+
 	urlStr := fmt.Sprintf("%s://%s", network, addr)
-	c, _, err := websocket.DefaultDialer.Dial(urlStr, nil)
+	c, _, err := dialer.Dial(urlStr, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds MQTT over WebSocket support. I added WebSocket dialer to support `ws` and `wss` network.

As MQTT over WebSocket is a part of MQTT specification (not MODE specific), `MqttClient` has the option. A client application needs to set `WithUseWebSocket` option for `NewMqttClient` function.

To use standard MQTT (TCP)
```
client := mode.NewMqttClient("mqtt.tinkermode.com", 8883, mode.WithMqttDelegate(delegate))
```

To use WebSocket
```
client := mode.NewMqttClient("mqtt.tinkermode.com", 443, mode.WithUseWebSocket(true), mode.WithMqttDelegate(delegate))
```

**Tested patterns**
I set up an actual MQTT broker and HTTP proxy server on my laptop. I also created a self-signed client certificate to test TLS. 

- With HTTP proxy, without HTTP proxy
- WS with device ID and device API key
- WSS with device ID and device API key
- WSS with client certificate (and without device ID and device API key)